### PR TITLE
Multi-season packs: Added protection tag for unmonitored downloads removal

### DIFF
--- a/config/config.conf-Explained
+++ b/config/config.conf-Explained
@@ -72,6 +72,7 @@ REMOVE_ORPHANS  = False
 # Steers whether downloads belonging to unmonitored movies/TV shows are removed from the queue
 # Note: Will only remove from queue if all tv shows depending on the same download are unmonitored
 # Unmonitored downloads are not added to the block list
+# Note: Since Sonarr does not support multi-season packs, if you download one you should protect it with the below NO_STALLED_REMOVAL_QBIT_TAG.
 # Type: Boolean
 # Permissible Values: True, False
 # Is Mandatory: No (Defaults to False)
@@ -87,6 +88,7 @@ PERMITTED_ATTEMPTS= 3
 ###### NO_STALLED_REMOVAL_QBIT_TAG ######
 # Downloads in qBittorrent tagged with this tag will not be killed even if they are stalled
 # Tag is automatically created in qBittorrent (required qBittorrent is reachable on QBITTORRENT_URL )
+# Also protects unmonitored downloads from being removed (relevant for multi-season packs)
 # Type: String
 # Is Mandatory: No (Defaults to "Don't Kill If Stalled")
 NO_STALLED_REMOVAL_QBIT_TAG= Don't Kill If Stalled


### PR DESCRIPTION
Added protection for unmonitored downloads ; applying  the tag in qbit now will not remove unmonitored downloads either (identically to stalled downloads)

Reason being that this way multi season packs can still be downloaded (else they may have been removed)