### PR TITLE
Fix UnboundLocalError: 'qbitItems' referenced before assignment

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,8 +47,8 @@ async def getProtectedAndPrivateFromQbit(settingsDict):
                 qbitItem['is_private'] = qbitItemProperties.get('is_private', None) # Adds the is_private flag to qbitItem info for simplified logging
                 if qbitItemProperties.get('is_private', False):
                     privateDowloadIDs.append(str.upper(qbitItem['hash']))
+        logger.debug('main/getProtectedAndPrivateFromQbit/qbitItems: %s', str([{"hash": str.upper(item["hash"]), "name": item["name"], "tags": item["tags"], "is_private": item.get("is_private", None)} for item in qbitItems]))
     
-    logger.debug('main/getProtectedAndPrivateFromQbit/qbitItems: %s', str([{"hash": str.upper(item["hash"]), "name": item["name"], "tags": item["tags"], "is_private": item.get("is_private", None)} for item in qbitItems]))
     logger.debug('main/getProtectedAndPrivateFromQbit/protectedDownloadIDs: %s', str(protectedDownloadIDs))
     logger.debug('main/getProtectedAndPrivateFromQbit/privateDowloadIDs: %s', str(privateDowloadIDs))   
 


### PR DESCRIPTION
Error:
`UnboundLocalError: local variable 'qbitItems' referenced before assignment`
Happening at application start.

Application crash at startup if QBITTORRENT_URL is not set due to logger accessing un-assigned variable, by moving this log line into the if statement it should prevent the issue.