### PR TITLE
Only check torrents during slow check

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Steers which type of cleaning is applied to the downloads queue
 **REMOVE_SLOW**
 - Steers whether slow downloads are removed from the queue
 - Slow downloads are added to the blocklist, so that they are not re-requested in the future
+- Important: Will only be run for torrents
 - Type: Boolean
 - Permissible Values: True, False
 - Is Mandatory: No (Defaults to False)

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Steers which type of cleaning is applied to the downloads queue
 **REMOVE_STALLED**
 - Steers whether stalled downloads with no connections are removed from the queue
 - These downloads are added to the blocklist, so that they are not re-requested in the future
+- Important: This only works with qbit
 - Type: Boolean
 - Permissible Values: True, False
 - Is Mandatory: No (Defaults to False)

--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -15,7 +15,6 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
         alreadyCheckedDownloadIDs = []
         for queueItem in queue['records']:
             if 'downloadId' in queueItem and 'size' in queueItem and 'sizeleft' in queueItem and 'status' in queueItem and 'protocol' in queueItem:
-                #  either size left isn't 0 OR it is 0 and so issize (a torrent/download that never started)
                 if queueItem['downloadId'] not in alreadyCheckedDownloadIDs and queueItem['protocol'] == 'torrent':
                     alreadyCheckedDownloadIDs.append(queueItem['downloadId']) # One downloadId may occur in multiple queueItems - only check once for all of them per iteration
                     # determine if the downloaded bit on average between this and the last iteration is greater than the min threshold

--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -14,9 +14,9 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
         affectedItems = []
         alreadyCheckedDownloadIDs = []
         for queueItem in queue['records']:
-            if 'downloadId' in queueItem and 'size' in queueItem and 'sizeleft' in queueItem and 'status' in queueItem:
-                #  either size left isn't 0 OR it is 0 and so is size (a torrent/download that never started)
-                if queueItem['downloadId'] not in alreadyCheckedDownloadIDs and (queueItem['sizeleft'] != 0 or queueItem['size'] == 0):
+            if 'downloadId' in queueItem and 'size' in queueItem and 'sizeleft' in queueItem and 'status' in queueItem and 'protocol' in queueItem:
+                #  either size left isn't 0 OR it is 0 and so issize (a torrent/download that never started)
+                if queueItem['downloadId'] not in alreadyCheckedDownloadIDs and queueItem['protocol'] == 'torrent':
                     alreadyCheckedDownloadIDs.append(queueItem['downloadId']) # One downloadId may occur in multiple queueItems - only check once for all of them per iteration
                     # determine if the downloaded bit on average between this and the last iteration is greater than the min threshold
                     downloadedSize, previousSize, increment, speed = await getDownloadedSize(settingsDict, queueItem, download_sizes_tracker, NAME)

--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -15,7 +15,7 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
         alreadyCheckedDownloadIDs = []
         for queueItem in queue['records']:
             if 'downloadId' in queueItem and 'size' in queueItem and 'sizeleft' in queueItem and 'status' in queueItem:
-                if queueItem['downloadId'] not in alreadyCheckedDownloadIDs:
+                if queueItem['downloadId'] not in alreadyCheckedDownloadIDs and queueItem['sizeleft'] > 0:
                     alreadyCheckedDownloadIDs.append(queueItem['downloadId']) # One downloadId may occur in multiple queueItems - only check once for all of them per iteration
                     # determine if the downloaded bit on average between this and the last iteration is greater than the min threshold
                     downloadedSize, previousSize, increment, speed = await getDownloadedSize(settingsDict, queueItem, download_sizes_tracker, NAME)

--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -15,7 +15,8 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
         alreadyCheckedDownloadIDs = []
         for queueItem in queue['records']:
             if 'downloadId' in queueItem and 'size' in queueItem and 'sizeleft' in queueItem and 'status' in queueItem:
-                if queueItem['downloadId'] not in alreadyCheckedDownloadIDs and queueItem['sizeleft'] > 0:
+                #  either size left isn't 0 OR it is 0 and so is size (a torrent/download that never started)
+                if queueItem['downloadId'] not in alreadyCheckedDownloadIDs and (queueItem['sizeleft'] != 0 or queueItem['size'] == 0):
                     alreadyCheckedDownloadIDs.append(queueItem['downloadId']) # One downloadId may occur in multiple queueItems - only check once for all of them per iteration
                     # determine if the downloaded bit on average between this and the last iteration is greater than the min threshold
                     downloadedSize, previousSize, increment, speed = await getDownloadedSize(settingsDict, queueItem, download_sizes_tracker, NAME)


### PR DESCRIPTION
Hey, 

just stumbled across this cool idea to solve the problem.

From my initial testing i ran into two issues

* wasn't obvious that the stalled job only works with qbit - so updated the readme
* The slow check doesn't account for the fact there may be post processing occurring, so ive added logic to avoid running it for downloads that  have 0 bytes left

Ive just gotta build and test this. ill let you know when ive done this

Edit: instead its been adjusted to just only run slow checks for torrents only