### PR TITLE
Preload requirements file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,8 @@ ENV IS_IN_DOCKER 1
 
 WORKDIR /app
 
-COPY . .
+COPY ./docker/requirements.txt ./docker/requirements.txt
 RUN pip install --no-cache-dir -r docker/requirements.txt
-
+COPY . .
 
 CMD ["python", "main.py"]


### PR DESCRIPTION
Due to the fact version pinning is in use, there's no point in reinstalling deps each build.

Instead copy everything after dep install to increase caching

just speeds up local building to almost instant