### PR TITLE
Skipping slow check for items that have nothing left to download..

### DIFF
--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -17,6 +17,10 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
             if 'downloadId' in queueItem and 'size' in queueItem and 'sizeleft' in queueItem and 'status' in queueItem:
                 if queueItem['downloadId'] not in alreadyCheckedDownloadIDs:
                     alreadyCheckedDownloadIDs.append(queueItem['downloadId']) # One downloadId may occur in multiple queueItems - only check once for all of them per iteration
+                    if queueItem['sizeleft'] == 0: # Skip items that are finished downloading but are still marked as downloading. May be the case when files are moving
+                        logger.debug('remove_slow/skipping completed item marked as downloading: %s (Speed: %d KB/s, KB now: %s, KB previous: %s, Diff: %s, In Minutes: %s', \
+                            queueItem['title'], speed, downloadedSize, previousSize, increment, settingsDict['REMOVE_TIMER'])    
+                        continue
                     # determine if the downloaded bit on average between this and the last iteration is greater than the min threshold
                     downloadedSize, previousSize, increment, speed = await getDownloadedSize(settingsDict, queueItem, download_sizes_tracker, NAME)
                     if  queueItem['status'] == 'downloading' and \


### PR DESCRIPTION
...eventhough they are marked as "downloading" still

May be the case for items that are being moved post download from one file system to another, before going to "seeding" stage