### PR TITLE
[Bugfix] Actually remove failed imports

### DIFF
--- a/src/jobs/remove_failed_imports.py
+++ b/src/jobs/remove_failed_imports.py
@@ -20,7 +20,7 @@ async def remove_failed_imports(settingsDict, BASE_URL, API_KEY, NAME, deleted_d
 
                 if queueItem['status'] == 'completed' \
                     and queueItem['trackedDownloadStatus'] == 'warning' \
-                    and queueItem['trackedDownloadState'] == 'importPending':
+                    and (queueItem['trackedDownloadState'] == 'importPending' or queueItem['trackedDownloadState'] == 'importFailed'):
                     
                     for statusMessage in queueItem['statusMessages']:
                         if not settingsDict['FAILED_IMPORT_MESSAGE_PATTERNS'] or any(any(pattern in message for pattern in settingsDict['FAILED_IMPORT_MESSAGE_PATTERNS']) for message in statusMessage.get('messages', [])):


### PR DESCRIPTION
While trying to use decluttarr with my Lidarr setup, I noticed that there were some imports that were failing but were never actually removed from the queue. I took a look at the logs and the `trackedDownloadState` of these items was `importFailed` instead of `importPending` which is expected.

This PR adds another condition to the logic that checks for `importFailed` as well and removes the affected downloads.

I tried to screenshot this but it's a little difficult to show without diving into the debug logs!

<img width="1912" alt="Screenshot 2024-06-03 at 4 40 58 PM" src="https://github.com/ManiMatter/decluttarr/assets/13932741/18a510d1-2378-48ca-93b6-6e0f53adff7b">