### PR TITLE
Remove Slow Downloads stuck on 0kb size / MetaData Not being detected as slow.

### DIFF
--- a/src/jobs/remove_metadata_missing.py
+++ b/src/jobs/remove_metadata_missing.py
@@ -1,4 +1,4 @@
-from src.utils.shared import (errorDetails, formattedQueueInfo, get_queue, privateTrackerCheck, protectedDownloadCheck, execute_checks, permittedAttemptsCheck, remove_download)
+from src.utils.shared import (has_keys, errorDetails, formattedQueueInfo, get_queue, privateTrackerCheck, protectedDownloadCheck, execute_checks, permittedAttemptsCheck, remove_download)
 import sys, os, traceback
 import logging, verboselogs
 logger = verboselogs.VerboseLogger(__name__)
@@ -13,7 +13,16 @@ async def remove_metadata_missing(settingsDict, BASE_URL, API_KEY, NAME, deleted
         # Find items affected
         affectedItems = []
         for queueItem in queue['records']: 
-            if 'errorMessage' in queueItem and 'status' in queueItem:
+            # Check if the Status is downloading, and is size 0 (no metadata downloaded yet/stuck)
+            if has_keys(queueItem, ['status', 'size', 'sizeleft', 'title']):
+                ## If the File is stuck on "downloading metadata" -- e.g. a magnet link, resolving to a torrent. This may also be true
+                ## However, for that case the size == 0, (since it doesn't exist yet). all other files are >0            
+                if queueItem['status'] == 'downloading':
+                    logger.info('>>> Detected Metadata %s download that is 0kb is slow or stuck. (Failed Metadata) Adding to missing metadata list.',queueItem['title'])    
+                    affectedItems.append(queueItem)
+            
+            ## Checking if Status is queued , and has an error
+            if has_keys(queueItem, ['errorMessage', 'status']):
                 if  queueItem['status'] == 'queued' and queueItem['errorMessage'] == 'qBittorrent is downloading metadata':
                     affectedItems.append(queueItem)
         affectedItems = await execute_checks(settingsDict, affectedItems, failType, BASE_URL, API_KEY, NAME, deleted_downloads, defective_tracker, privateDowloadIDs, protectedDownloadIDs, 

--- a/src/jobs/remove_metadata_missing.py
+++ b/src/jobs/remove_metadata_missing.py
@@ -17,7 +17,7 @@ async def remove_metadata_missing(settingsDict, BASE_URL, API_KEY, NAME, deleted
             if has_keys(queueItem, ['status', 'size', 'sizeleft', 'title']):
                 ## If the File is stuck on "downloading metadata" -- e.g. a magnet link, resolving to a torrent. This may also be true
                 ## However, for that case the size == 0, (since it doesn't exist yet). all other files are >0            
-                if queueItem['status'] == 'downloading':
+                if queueItem['status'] == 'downloading' and queueItem['sizeleft'] == 0 and queue['size'] == 0:
                     logger.info('>>> Detected Metadata %s download that is 0kb is slow or stuck. (Failed Metadata) Adding to missing metadata list.',queueItem['title'])    
                     affectedItems.append(queueItem)
             

--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -31,7 +31,7 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
                         if queueItem['sizeleft'] == 0: # Skip items that are finished downloading but are still marked as downloading. May be the case when files are moving
 
                             ## If the File is stuck on "downloading metadata" -- e.g. a magnet link, resolving to a torrent. This may also be true
-                            ## However, for that case the sizeLeft == 0, and the total_size == -1 (since it doesn't exist yet)
+                            ## However, for that case the sizeLeft == -1, (since it doesn't exist yet). all other files are >0
                             if queueItem['total_size'] > 0:
                                 # If the total_size exists, then we know it was downloaded.
                                 logger.info('>>> Detected %s download that has completed downloading - skipping check (torrent files likely in process of being moved): %s',failType, queueItem['title'])    

--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -36,6 +36,12 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
                                 # If the total_size exists, then we know it was downloaded.
                                 logger.info('>>> Detected %s download that has completed downloading - skipping check (torrent files likely in process of being moved): %s',failType, queueItem['title'])    
                                 continue
+                            else:
+                                # MetaData is too slow to download/is stuck
+                                logger.info('>>> Detected %s Meta Data is slow or stuck. Adding to queue.',queueItem['title'])    
+                                affectedItems.append(queueItem)
+                                continue
+
 
                         # determine if the downloaded bit on average between this and the last iteration is greater than the min threshold
                         downloadedSize, previousSize, increment, speed = await getDownloadedSize(settingsDict, queueItem, download_sizes_tracker, NAME)

--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -37,7 +37,7 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
                                 logger.info('>>> Detected %s download that has completed downloading - skipping check (torrent files likely in process of being moved): %s',failType, queueItem['title'])    
                                 continue
                             else:
-                                # MetaData is too slow to download/is stuck
+                                # MetaData is 0kb; it is too slow to download/is stuck . Could also be a malformed torrent.
                                 logger.info('>>> Detected %s download that is 0kb is slow or stuck. (Failed Metadata or Torrent) Adding to queue.',queueItem['title'])    
                                 affectedItems.append(queueItem)
                                 continue

--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -38,7 +38,7 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
                                 continue
                             else:
                                 # MetaData is too slow to download/is stuck
-                                logger.info('>>> Detected %s Meta Data is slow or stuck. Adding to queue.',queueItem['title'])    
+                                logger.info('>>> Detected %s download that is 0kb is slow or stuck. (Failed Metadata or Torrent) Adding to queue.',queueItem['title'])    
                                 affectedItems.append(queueItem)
                                 continue
 

--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -29,9 +29,8 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
                         continue
                     if queueItem['status'] == 'downloading':
                         if queueItem['sizeleft'] == 0: # Skip items that are finished downloading but are still marked as downloading. May be the case when files are moving
-                            logger.info('>>> Detected %s download that has completed downloading - skipping check (torrent files likely in process of being moved): %s',failType, queueItem['title'])   
+                            logger.info('>>> Detected %s download that has completed downloading - skipping check (torrent files likely in process of being moved): %s',failType, queueItem['title'])
                             continue
-
 
                         # determine if the downloaded bit on average between this and the last iteration is greater than the min threshold
                         downloadedSize, previousSize, increment, speed = await getDownloadedSize(settingsDict, queueItem, download_sizes_tracker, NAME)

--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -28,9 +28,7 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
                     if queueItem['protocol'] == 'usenet': # No need to check for speed for usenet, since there users pay for speed
                         continue
                     if queueItem['status'] == 'downloading':
-                        
                         if queueItem['sizeleft'] == 0: # Skip items that are finished downloading but are still marked as downloading. May be the case when files are moving
-
                             logger.info('>>> Detected %s download that has completed downloading - skipping check (torrent files likely in process of being moved): %s',failType, queueItem['title'])   
                             continue
 

--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -28,19 +28,11 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
                     if queueItem['protocol'] == 'usenet': # No need to check for speed for usenet, since there users pay for speed
                         continue
                     if queueItem['status'] == 'downloading':
+                        
                         if queueItem['sizeleft'] == 0: # Skip items that are finished downloading but are still marked as downloading. May be the case when files are moving
 
-                            ## If the File is stuck on "downloading metadata" -- e.g. a magnet link, resolving to a torrent. This may also be true
-                            ## However, for that case the size == 0, (since it doesn't exist yet). all other files are >0
-                            if queueItem['size'] > 0:
-                                # If the total_size exists, then we know it was downloaded.
-                                logger.info('>>> Detected %s download that has completed downloading - skipping check (torrent files likely in process of being moved): %s',failType, queueItem['title'])    
-                                continue
-                            else:
-                                # MetaData is 0kb; it is too slow to download/is stuck . Could also be a malformed torrent.
-                                logger.info('>>> Detected %s download that is 0kb is slow or stuck. (Failed Metadata or Torrent) Adding to queue.',queueItem['title'])    
-                                affectedItems.append(queueItem)
-                                continue
+                            logger.info('>>> Detected %s download that has completed downloading - skipping check (torrent files likely in process of being moved): %s',failType, queueItem['title'])   
+                            continue
 
 
                         # determine if the downloaded bit on average between this and the last iteration is greater than the min threshold

--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -22,7 +22,7 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
                 return 0
 
         for queueItem in queue['records']:
-            if 'downloadId' in queueItem and 'size' in queueItem and 'sizeleft' in queueItem and 'status' in queueItem and 'total_size' in queueItem:
+            if 'downloadId' in queueItem and 'size' in queueItem and 'sizeleft' in queueItem and 'status' in queueItem:
                 if queueItem['downloadId'] not in alreadyCheckedDownloadIDs:
                     alreadyCheckedDownloadIDs.append(queueItem['downloadId']) # One downloadId may occur in multiple queueItems - only check once for all of them per iteration
                     if queueItem['protocol'] == 'usenet': # No need to check for speed for usenet, since there users pay for speed
@@ -31,11 +31,12 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
                         if queueItem['sizeleft'] == 0: # Skip items that are finished downloading but are still marked as downloading. May be the case when files are moving
 
                             ## If the File is stuck on "downloading metadata" -- e.g. a magnet link, resolving to a torrent. This may also be true
-                            ## However, for that case the sizeLeft == -1, (since it doesn't exist yet). all other files are >0
-                            if queueItem['total_size'] > 0:
+                            ## However, for that case the size == 0, (since it doesn't exist yet). all other files are >0
+                            if queueItem['size'] > 0:
                                 # If the total_size exists, then we know it was downloaded.
                                 logger.info('>>> Detected %s download that has completed downloading - skipping check (torrent files likely in process of being moved): %s',failType, queueItem['title'])    
                                 continue
+
                         # determine if the downloaded bit on average between this and the last iteration is greater than the min threshold
                         downloadedSize, previousSize, increment, speed = await getDownloadedSize(settingsDict, queueItem, download_sizes_tracker, NAME)
                         if queueItem['downloadId'] in download_sizes_tracker.dict and speed is not None:

--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -32,7 +32,7 @@ async def remove_slow(settingsDict, BASE_URL, API_KEY, NAME, deleted_downloads, 
 
                             ## If the File is stuck on "downloading metadata" -- e.g. a magnet link, resolving to a torrent. This may also be true
                             ## However, for that case the sizeLeft == 0, and the total_size == -1 (since it doesn't exist yet)
-                            if queueItem['total_size'] >= 0:
+                            if queueItem['total_size'] > 0:
                                 # If the total_size exists, then we know it was downloaded.
                                 logger.info('>>> Detected %s download that has completed downloading - skipping check (torrent files likely in process of being moved): %s',failType, queueItem['title'])    
                                 continue

--- a/src/utils/shared.py
+++ b/src/utils/shared.py
@@ -1,9 +1,13 @@
 # Shared Functions
 import logging, verboselogs
+from typing import List
 logger = verboselogs.VerboseLogger(__name__)
 from src.utils.rest import (rest_get, rest_delete, rest_post)
 from src.utils.nest_functions import (add_keys_nested_dict, nested_get)
 import sys, os, traceback
+
+def has_keys(dictonary, keys: List[str]) -> bool:
+    return all(key in dictonary for key in keys)
 
 async def get_queue(BASE_URL, API_KEY, params = {}):
     # Retrieves the current queue

--- a/src/utils/shared.py
+++ b/src/utils/shared.py
@@ -6,8 +6,8 @@ from src.utils.rest import (rest_get, rest_delete, rest_post)
 from src.utils.nest_functions import (add_keys_nested_dict, nested_get)
 import sys, os, traceback
 
-def has_keys(dictonary, keys: List[str]) -> bool:
-    return all(key in dictonary for key in keys)
+def has_keys(dictionary, keys: List[str]) -> bool:
+    return all(key in dictionary for key in keys)
 
 async def get_queue(BASE_URL, API_KEY, params = {}):
     # Retrieves the current queue


### PR DESCRIPTION
<img width="1241" alt="image" src="https://github.com/ManiMatter/decluttarr/assets/128746884/56b2e899-4c2f-40bb-a352-d85d9b2becbc">

Currently these use cases fail to be detected. For torrents which are not very popular you may fail to even download the magnet file.

<img width="1241" alt="image" src="https://github.com/ManiMatter/decluttarr/assets/128746884/0ccc9e9c-a263-4efe-94d3-6263c6e62dfc">

Instead it was detected as a big download that might be moving soon... This will fix the issue, and ensure that something is downloaded.


Example JSON of a Magnet File that is not downloaded.

`[INFO]:  {'seriesId': 90, 'episodeId': 8097, 'seasonNumber': 4, 'languages': [], 'quality': {'quality': {'id': 5, 'name': 'WEBDL-720p', 'source': 'web', 'resolution': 720}, 'revision': {'version': 1, 'real': 0, 'isRepack': False}}, 'customFormats': [], 'customFormatScore': 0, 'size': 0, 'title': 'fc2e9e29471ed570771be8dfa157c512fad6e6eb', 'sizeleft': 0, 'added': '2024-06-10T00:16:14Z', 'status': 'downloading', 'trackedDownloadStatus': 'ok', 'trackedDownloadState': 'downloading', 'statusMessages': [], 'downloadId': 'FC2E9E29471ED570771BE8DFA157C512FAD6E6EB', 'protocol': 'torrent', 'downloadClient': 'qbit', 'downloadClientHasPostImportCategory': False, 'indexer': 'TorrentDownload (Prowlarr)', 'episodeHasFile': False, 'id': 333611039} 
`


<img width="1241" alt="image" src="https://github.com/ManiMatter/decluttarr/assets/128746884/a4e47f92-603e-46ba-a373-93c88fc93c9f">


Example logs when it is working.