### PR TITLE
Check for both Size Total and Size Remaining

### DIFF
--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -56,7 +56,7 @@ async def remove_slow(
                         continue
                     if queueItem["status"] == "downloading":
                         if (
-                            queueItem["sizeleft"] == 0
+                            queueItem["size"] > 0 and queueItem["sizeleft"] == 0
                         ):  # Skip items that are finished downloading but are still marked as downloading. May be the case when files are moving
                             logger.info(
                                 ">>> Detected %s download that has completed downloading - skipping check (torrent files likely in process of being moved): %s",


### PR DESCRIPTION
In the event of a "super slow" torrent that has difficulty starting, arr tools will report that the entry has both 0 bytes remaining _and_ a total 0 filesize.  

This checks that the torrent filesize is greater than 0, so that a persistent "0 filesize" torrent will be flagged as slow.