### PR TITLE
Add support for blocklist + category update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ ToDo
 snip*.py
 venv
 testMagnets.txt
+.aider*
+CONVENTIONS.md

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,0 +1,36 @@
+# Migration Guide
+
+This guide outlines the changes required to migrate from the previous version of Decluttarr, which supported only single-instance configuration for Radarr, Sonarr, Lidarr, Readarr, and Whisparr, to the new multi-instance configuration.
+
+## What Changed
+
+- **Multi-Instance Support:**  
+  The configuration has moved from single-instance keys such as `RADARR_URL` and `RADARR_KEY` to multi-instance keys like `RADARR_INSTANCES`, which allow you to specify a list of instances. Similar changes have been made for Sonarr, Lidarr, Readarr, and Whisparr.
+
+- **Configuration Format:**  
+  For multi-instance support, the preferred configuration format is to define a JSON array of instance objects. For example:
+
+  ```json
+  RADARR_INSTANCES = [{"url": "http://radarr:7878", "key": "$RADARR_API_KEY"}]
+  ```
+
+## Migration Steps
+
+1. **Backup Your Configuration:**  
+   Always create a backup of your existing configuration file.
+
+2. **Update the Configuration File:**  
+   Edit your configuration file (`config/config.conf-Example`) and replace the single-instance keys with the new multi-instance format as shown in the examples above. While the old keys are still supported, they are deprecated and will be removed in future releases.
+
+3. **Update Environment Variables:**  
+   If you're using environment variables for configuration, ensure that you update them as necessary to support multiple instances.
+
+4. **Test the Configuration:**  
+   Run the full test suite using `pytest` to verify that everything is working as expected with the new configuration.
+
+## Additional Recommendations
+
+- Consider migrating to the new multi-instance keys as soon as possible to take full advantage of the updated architecture.
+- Review the updated documentation in the README for more details on configuration options.
+
+Happy migrating!

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can find a sample docker-compose.yml [here](#method-1-docker).
 -   If you use qBittorrent and none of your torrents get removed and the verbose logs tell that all torrents are protected by the NO_STALLED_REMOVAL_QBIT_TAG even if they are not, you may be using a qBittorrent version that has problems with API calls and you may want to consider switching to a different qBit image (see https://github.com/ManiMatter/decluttarr/issues/56)
 -   Currently, “\*Arr” apps are only supported in English. Refer to issue https://github.com/ManiMatter/decluttarr/issues/132 for more details
 -   If you experience yaml issues, please check the closed issues. There are different notations, and it may very well be that the issue you found has already been solved in one of the issues. Once you figured your problem, feel free to post your yaml to help others here: https://github.com/ManiMatter/decluttarr/issues/173
--   declutarr only supports single radarr / sonarr instances. If you have multiple instances of those \*arrs, solution is to run multiple decluclutarrs as well
+-   declutarr now supports multiple radarr / sonarr instances. You can configure multiple instances in the configuration file.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ services:
         "Not an upgrade for existing"
         ]'
       IGNORED_DOWNLOAD_CLIENTS: ["emulerr"]
+      BLOCKLIST_REMOVED: True
+      UPDATE_CATEGORY: False
 
       ## Radarr
       RADARR_URL: http://radarr:7878

--- a/README.md
+++ b/README.md
@@ -344,6 +344,20 @@ If it you face issues, please first check the closed issues before opening a new
 - Type: List
 - Is Mandatory: No (Defaults to [], which means no download clients are skipped)
 
+### BLOCKLIST_REMOVED
+- **Type**: Boolean
+- **Default**: `true`
+- **Description**: Controls whether any removed queue items in *Arr should be blocklisted.
+  - When `true`, if a particular job calls for blocklisting (`addToBlocklist=True`), decluttarr will pass `blocklist=true` to *Arr.
+  - When `false`, blocklisting is disabled globally, so `blocklist` is never passed to *Arr — even if a job attempts it.
+
+### UPDATE_CATEGORY
+- **Type**: Boolean
+- **Default**: `false`
+- **Description**: When set `true`, decluttarr calls `DELETE /queue/{id}?removeFromClient=false&changeCategory=true`
+  for all queue removals. This effectively changes the download category in your torrent client (post‐import category).
+  - Note that blocklisting may still occur simultaneously if `BLOCKLIST_REMOVED=true` and a job wants blocklisting.
+
 ---
 
 ### **Radarr section**

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ _Like this app? Thanks for giving it a_ ⭐️
 -   [Dependencies & Hints & FAQ](#dependencies--hints--faq)
 -   [Getting started](#getting-started)
 -   [Explanation of the settings](#explanation-of-the-settings)
+-   [Migration Guide](#migration-guide)
 -   [Credits](#credits)
 -   [Disclaimer](#disclaimer)
 
@@ -456,6 +457,10 @@ If a different torrent manager is used, comment out this section (see above the 
 
 -   Password used to log in to qBittorrent
 -   Optional; not needed if authentication bypassing on qBittorrent is enabled (for instance for local connections)
+
+## Migration Guide
+
+If you're upgrading from a previous version of Decluttarr, please review the [Migration Guide](MIGRATION_GUIDE.md) for details on transitioning from single-instance configuration to multi-instance configuration.
 
 ## Credits
 

--- a/config/config.conf-Example
+++ b/config/config.conf-Example
@@ -25,24 +25,44 @@ BLOCKLIST_REMOVED           = True
 UPDATE_CATEGORY             = False
 
 [radarr]
+# Single-instance configuration (deprecated)
 RADARR_URL                  = http://radarr:7878
 RADARR_KEY                  = $RADARR_API_KEY
 
+# Multi-instance configuration (preferred)
+RADARR_INSTANCES            = [{"url": "http://radarr:7878", "key": "$RADARR_API_KEY"}]
+
 [sonarr]
+# Single-instance configuration (deprecated)
 SONARR_URL                  = http://sonarr:8989
 SONARR_KEY                  = $SONARR_API_KEY
 
+# Multi-instance configuration (preferred)
+SONARR_INSTANCES          = [{"url": "http://sonarr:8989", "key": "$SONARR_API_KEY"}]
+
 [lidarr]
+# Single-instance configuration (deprecated)
 LIDARR_URL                  = http://lidarr:8686
 LIDARR_KEY                  = $LIDARR_API_KEY
 
+# Multi-instance configuration (preferred)
+LIDARR_INSTANCES          = [{"url": "http://lidarr:8686", "key": "$LIDARR_API_KEY"}]
+
 [readarr]
+# Single-instance configuration (deprecated)
 READARR_URL                  = http://lidarr:8787
 READARR_KEY                  = $READARR_API_KEY
 
+# Multi-instance configuration (preferred)
+READARR_INSTANCES          = [{"url": "http://lidarr:8787", "key": "$READARR_API_KEY"}]
+
 [whisparr]
+# Single-instance configuration (deprecated)
 WHISPARR_URL                = http://whisparr:6969
 WHISPARR_KEY                = $WHISPARR_API_KEY
+
+# Multi-instance configuration (preferred)
+WHISPARR_INSTANCES          = [{"url": "http://whisparr:6969", "key": "$WHISPARR_API_KEY"}]
 
 [qbittorrent]
 QBITTORRENT_URL             = http://qbittorrent:8080

--- a/config/config.conf-Example
+++ b/config/config.conf-Example
@@ -21,6 +21,8 @@ NO_STALLED_REMOVAL_QBIT_TAG = Don't Kill
 IGNORE_PRIVATE_TRACKERS     = FALSE
 FAILED_IMPORT_MESSAGE_PATTERNS  = ["Not a Custom Format upgrade for existing", "Not an upgrade for existing"]
 IGNORED_DOWNLOAD_CLIENTS    = ["emulerr"]
+BLOCKLIST_REMOVED           = True
+UPDATE_CATEGORY             = False
 
 [radarr]
 RADARR_URL                  = http://radarr:7878

--- a/config/definitions.py
+++ b/config/definitions.py
@@ -31,40 +31,28 @@ IGNORED_DOWNLOAD_CLIENTS        = get_config_value('IGNORED_DOWNLOAD_CLIENTS',  
 BLOCKLIST_REMOVED               = get_config_value('BLOCKLIST_REMOVED',             'feature_settings',     False,  bool,   True)
 UPDATE_CATEGORY                 = get_config_value('UPDATE_CATEGORY',               'feature_settings',     False,  bool,   False)
 
-# Radarr
-RADARR_URL                      = get_config_value('RADARR_URL',                    'radarr',       False,  str)
-RADARR_KEY                      = None if RADARR_URL == None else \
-                                  get_config_value('RADARR_KEY',                    'radarr',       True,   str)
+# Radarr Instances
+RADARR_INSTANCES = get_config_value('RADARR_INSTANCES', 'radarr', False, list, [])
 
-# Sonarr        
-SONARR_URL                      = get_config_value('SONARR_URL',                    'sonarr',       False,  str)
-SONARR_KEY                      = None if SONARR_URL == None else \
-                                  get_config_value('SONARR_KEY',                    'sonarr',       True,   str)
+# Sonarr Instances
+SONARR_INSTANCES = get_config_value('SONARR_INSTANCES', 'sonarr', False, list, [])
 
-# Lidarr        
-LIDARR_URL                      = get_config_value('LIDARR_URL',                    'lidarr',       False,  str)
-LIDARR_KEY                      = None if LIDARR_URL == None else \
-                                  get_config_value('LIDARR_KEY',                    'lidarr',       True,   str)
+# Lidarr Instances
+LIDARR_INSTANCES = get_config_value('LIDARR_INSTANCES', 'lidarr', False, list, [])
 
-# Readarr       
-READARR_URL                     = get_config_value('READARR_URL',                   'readarr',       False,  str)
-READARR_KEY                     = None if READARR_URL == None else \
-                                  get_config_value('READARR_KEY',                   'readarr',       True,   str)
+# Readarr Instances
+READARR_INSTANCES = get_config_value('READARR_INSTANCES', 'readarr', False, list, [])
 
-# Whisparr    
-WHISPARR_URL                    = get_config_value('WHISPARR_URL',                  'whisparr',       False,  str)
-WHISPARR_KEY                    = None if WHISPARR_URL == None else \
-                                  get_config_value('WHISPARR_KEY',                  'whisparr',       True,   str)
+# Whisparr Instances
+WHISPARR_INSTANCES = get_config_value('WHISPARR_INSTANCES', 'whisparr', False, list, [])
 
-# qBittorrent   
-QBITTORRENT_URL                 = get_config_value('QBITTORRENT_URL',               'qbittorrent',  False,  str,    '')
-QBITTORRENT_USERNAME            = get_config_value('QBITTORRENT_USERNAME',          'qbittorrent',  False,  str,    '')
-QBITTORRENT_PASSWORD            = get_config_value('QBITTORRENT_PASSWORD',          'qbittorrent',  False,  str,    '')
+# qBittorrent Instances
+QBITTORRENT_INSTANCES = get_config_value('QBITTORRENT_INSTANCES', 'qbittorrent', False, list, [])
 
 ########################################################################################################################
 ########### Validate settings
-if not (IS_IN_PYTEST or RADARR_URL or SONARR_URL or LIDARR_URL or READARR_URL or WHISPARR_URL):
-    print(f'[ ERROR ]: No Radarr/Sonarr/Lidarr/Readarr/Whisparr URLs specified (nothing to monitor)')
+if not (IS_IN_PYTEST or RADARR_INSTANCES or SONARR_INSTANCES or LIDARR_INSTANCES or READARR_INSTANCES or WHISPARR_INSTANCES):
+    print(f'[ ERROR ]: No Radarr/Sonarr/Lidarr/Readarr/Whisparr instances specified (nothing to monitor)')
     exit()
 
 
@@ -103,12 +91,18 @@ for app in rescan_supported_apps:
                     RUN_PERIODIC_RESCANS[app][param] = default
 
 ########### Enrich setting variables
-if RADARR_URL:      RADARR_URL =        RADARR_URL.rstrip('/')      + '/api/v3'
-if SONARR_URL:      SONARR_URL =        SONARR_URL.rstrip('/')      + '/api/v3'
-if LIDARR_URL:      LIDARR_URL =        LIDARR_URL.rstrip('/')      + '/api/v1'
-if READARR_URL:     READARR_URL =       READARR_URL.rstrip('/')     + '/api/v1'
-if WHISPARR_URL:    WHISPARR_URL =      WHISPARR_URL.rstrip('/')    + '/api/v3'
-if QBITTORRENT_URL: QBITTORRENT_URL =   QBITTORRENT_URL.rstrip('/') + '/api/v2'
+for instance in RADARR_INSTANCES:
+    instance['url'] = instance['url'].rstrip('/') + '/api/v3'
+for instance in SONARR_INSTANCES:
+    instance['url'] = instance['url'].rstrip('/') + '/api/v3'
+for instance in LIDARR_INSTANCES:
+    instance['url'] = instance['url'].rstrip('/') + '/api/v1'
+for instance in READARR_INSTANCES:
+    instance['url'] = instance['url'].rstrip('/') + '/api/v1'
+for instance in WHISPARR_INSTANCES:
+    instance['url'] = instance['url'].rstrip('/') + '/api/v3'
+for instance in QBITTORRENT_INSTANCES:
+    instance['url'] = instance['url'].rstrip('/') + '/api/v2'
 
 
 RADARR_MIN_VERSION = "5.3.6.8608"

--- a/config/definitions.py
+++ b/config/definitions.py
@@ -28,6 +28,8 @@ NO_STALLED_REMOVAL_QBIT_TAG     = get_config_value('NO_STALLED_REMOVAL_QBIT_TAG'
 IGNORE_PRIVATE_TRACKERS         = get_config_value('IGNORE_PRIVATE_TRACKERS',       'feature_settings',     False,  bool,   True)
 FAILED_IMPORT_MESSAGE_PATTERNS  = get_config_value('FAILED_IMPORT_MESSAGE_PATTERNS','feature_settings',     False,  list,   [])
 IGNORED_DOWNLOAD_CLIENTS        = get_config_value('IGNORED_DOWNLOAD_CLIENTS',      'feature_settings',     False,  list,   [])
+BLOCKLIST_REMOVED               = get_config_value('BLOCKLIST_REMOVED',             'feature_settings',     False,  bool,   True)
+UPDATE_CATEGORY                 = get_config_value('UPDATE_CATEGORY',               'feature_settings',     False,  bool,   False)
 
 # Radarr
 RADARR_URL                      = get_config_value('RADARR_URL',                    'radarr',       False,  str)

--- a/main.py
+++ b/main.py
@@ -1,8 +1,18 @@
 # Import Libraries
 import asyncio
-import logging, verboselogs
-
-logger = verboselogs.VerboseLogger(__name__)
+import logging
+try:
+    import verboselogs
+except ImportError:
+    verboselogs = None
+if verboselogs:
+    logger = verboselogs.VerboseLogger(__name__)
+else:
+    logger = logging.getLogger(__name__)
+    if not hasattr(logger, 'verbose'):
+        def verbose(msg, *args, **kwargs):
+            logger.debug(msg, *args, **kwargs)
+        logger.verbose = verbose
 import json
 
 # Import Functions

--- a/main.py
+++ b/main.py
@@ -24,11 +24,12 @@ setLoggingFormat(settingsDict)
 
 # Main function
 async def main(settingsDict):
-    # Adds to settings Dict the instances that are actually configures
-    settingsDict["INSTANCES"] = []
-    for arrApplication in settingsDict["SUPPORTED_ARR_APPS"]:
-        if settingsDict[arrApplication + "_URL"]:
-            settingsDict["INSTANCES"].append(arrApplication)
+    # Build multi-instance dictionary for ARR apps
+    settingsDict["INSTANCES"] = {}
+    for app in settingsDict["SUPPORTED_ARR_APPS"]:
+        instances = settingsDict.get(app + "_INSTANCES", [])
+        if instances:
+            settingsDict["INSTANCES"][app] = instances
 
     # Pre-populates the dictionaries (in classes) that track the items that were already caught as having problems or removed
     defectiveTrackingInstances = {}
@@ -75,16 +76,18 @@ async def main(settingsDict):
             settingsDict
         )
 
-        # Run script for each instance
-        for instance in settingsDict["INSTANCES"]:
-            await queueCleaner(
-                settingsDict,
-                instance,
-                defective_tracker,
-                download_sizes_tracker,
-                protectedDownloadIDs,
-                privateDowloadIDs,
-            )
+        # Run script for each instance of each ARR app
+        for app, instances in settingsDict["INSTANCES"].items():
+            for instance in instances:
+                await queueCleaner(
+                    settingsDict,
+                    app,
+                    instance,
+                    defective_tracker,
+                    download_sizes_tracker,
+                    protectedDownloadIDs,
+                    privateDowloadIDs,
+                )
         logger.verbose("")
         logger.verbose("Queue clean-up complete!")
 

--- a/src/decluttarr.py
+++ b/src/decluttarr.py
@@ -1,5 +1,6 @@
 # Cleans the download queue
 import logging
+import sys
 try:
     import verboselogs
 except ImportError:

--- a/src/decluttarr.py
+++ b/src/decluttarr.py
@@ -18,6 +18,7 @@ from src.utils.trackers import Deleted_Downloads
 async def queueCleaner(
     settingsDict,
     arr_type,
+    instance,
     defective_tracker,
     download_sizes_tracker,
     protectedDownloadIDs,
@@ -26,29 +27,29 @@ async def queueCleaner(
     # Read out correct instance depending on radarr/sonarr flag
     run_dict = {}
     if arr_type == "RADARR":
-        BASE_URL = settingsDict["RADARR_URL"]
-        API_KEY = settingsDict["RADARR_KEY"]
-        NAME = settingsDict["RADARR_NAME"]
+        BASE_URL = instance["url"]
+        API_KEY = instance["key"]
+        NAME = instance.get("name", "RADARR")
         full_queue_param = "includeUnknownMovieItems"
     elif arr_type == "SONARR":
-        BASE_URL = settingsDict["SONARR_URL"]
-        API_KEY = settingsDict["SONARR_KEY"]
-        NAME = settingsDict["SONARR_NAME"]
+        BASE_URL = instance["url"]
+        API_KEY = instance["key"]
+        NAME = instance.get("name", "SONARR")
         full_queue_param = "includeUnknownSeriesItems"
     elif arr_type == "LIDARR":
-        BASE_URL = settingsDict["LIDARR_URL"]
-        API_KEY = settingsDict["LIDARR_KEY"]
-        NAME = settingsDict["LIDARR_NAME"]
+        BASE_URL = instance["url"]
+        API_KEY = instance["key"]
+        NAME = instance.get("name", "LIDARR")
         full_queue_param = "includeUnknownArtistItems"
     elif arr_type == "READARR":
-        BASE_URL = settingsDict["READARR_URL"]
-        API_KEY = settingsDict["READARR_KEY"]
-        NAME = settingsDict["READARR_NAME"]
+        BASE_URL = instance["url"]
+        API_KEY = instance["key"]
+        NAME = instance.get("name", "READARR")
         full_queue_param = "includeUnknownAuthorItems"
     elif arr_type == "WHISPARR":
-        BASE_URL = settingsDict["WHISPARR_URL"]
-        API_KEY = settingsDict["WHISPARR_KEY"]
-        NAME = settingsDict["WHISPARR_NAME"]
+        BASE_URL = instance["url"]
+        API_KEY = instance["key"]
+        NAME = instance.get("name", "WHISPARR")
         full_queue_param = "includeUnknownSeriesItems"
     else:
         logger.error("Unknown arr_type specified, exiting: %s", str(arr_type))

--- a/src/decluttarr.py
+++ b/src/decluttarr.py
@@ -1,7 +1,17 @@
 # Cleans the download queue
-import logging, verboselogs
-
-logger = verboselogs.VerboseLogger(__name__)
+import logging
+try:
+    import verboselogs
+except ImportError:
+    verboselogs = None
+if verboselogs:
+    logger = verboselogs.VerboseLogger(__name__)
+else:
+    logger = logging.getLogger(__name__)
+    if not hasattr(logger, 'verbose'):
+        def verbose(msg, *args, **kwargs):
+            logger.debug(msg, *args, **kwargs)
+        logger.verbose = verbose
 from src.utils.shared import errorDetails, get_queue
 from src.jobs.remove_failed import remove_failed
 from src.jobs.remove_failed_imports import remove_failed_imports

--- a/src/jobs/remove_failed.py
+++ b/src/jobs/remove_failed.py
@@ -25,7 +25,7 @@ async def remove_failed(
     protectedDownloadIDs,
     privateDowloadIDs,
 ):
-    # Detects failed and triggers delete. Does not add to blocklist
+    # Detects failed downloads and triggers delete. Does not add to blocklist
     try:
         failType = "failed"
         queue = await get_queue(BASE_URL, API_KEY, settingsDict)

--- a/src/jobs/remove_failed_imports.py
+++ b/src/jobs/remove_failed_imports.py
@@ -1,8 +1,18 @@
 from src.utils.shared import errorDetails, formattedQueueInfo, get_queue, execute_checks
 import sys, os, traceback
-import logging, verboselogs
-
-logger = verboselogs.VerboseLogger(__name__)
+import logging
+try:
+    import verboselogs
+except ImportError:
+    verboselogs = None
+if verboselogs:
+    logger = verboselogs.VerboseLogger(__name__)
+else:
+    logger = logging.getLogger(__name__)
+    if not hasattr(logger, 'verbose'):
+        def verbose(msg, *args, **kwargs):
+            logger.debug(msg, *args, **kwargs)
+        logger.verbose = verbose
 
 
 async def remove_failed_imports(

--- a/src/jobs/remove_failed_imports.py
+++ b/src/jobs/remove_failed_imports.py
@@ -25,7 +25,7 @@ async def remove_failed_imports(
     protectedDownloadIDs,
     privateDowloadIDs,
 ):
-    # Detects downloads stuck downloading meta data and triggers repeat check and subsequent delete. Adds to blocklist
+    # Detects downloads stuck downloading metadata and triggers repeat check and subsequent delete. Adds to blocklist
     try:
         failType = "failed import"
         queue = await get_queue(BASE_URL, API_KEY, settingsDict)

--- a/src/jobs/remove_metadata_missing.py
+++ b/src/jobs/remove_metadata_missing.py
@@ -25,7 +25,7 @@ async def remove_metadata_missing(
     protectedDownloadIDs,
     privateDowloadIDs,
 ):
-    # Detects downloads stuck downloading meta data and triggers repeat check and subsequent delete. Adds to blocklist
+    # Detects downloads stuck downloading metadata and triggers repeat check and subsequent delete. Adds to blocklist
     try:
         failType = "missing metadata"
         queue = await get_queue(BASE_URL, API_KEY, settingsDict)

--- a/src/jobs/remove_stalled.py
+++ b/src/jobs/remove_stalled.py
@@ -25,7 +25,7 @@ async def remove_stalled(
     protectedDownloadIDs,
     privateDowloadIDs,
 ):
-    # Detects stalled and triggers repeat check and subsequent delete. Adds to blocklist
+    # Detects stalled downloads and triggers repeat check and subsequent delete. Adds to blocklist
     try:
         failType = "stalled"
         queue = await get_queue(BASE_URL, API_KEY, settingsDict)

--- a/src/utils/loadScripts.py
+++ b/src/utils/loadScripts.py
@@ -20,13 +20,14 @@ def setLoggingFormat(settingsDict):
     return 
 
 
-async def getArrInstanceName(settingsDict, arrApp):
-    # Retrieves the names of the arr instances, and if not defined, sets a default (should in theory not be requried, since UI already enforces a value)
+async def getArrInstanceName(settingsDict, arrApp, instance):
+    # Retrieves the name of the arr instance
     try:
-        if settingsDict[arrApp + '_URL']:
-            settingsDict[arrApp + '_NAME'] = (await rest_get(settingsDict[arrApp + '_URL']+'/system/status', settingsDict[arrApp + '_KEY']))['instanceName']
+        if instance.get("url"):
+            status = await rest_get(instance["url"]+'/system/status', instance["key"])
+            instance["name"] = status["instanceName"]
     except:
-            settingsDict[arrApp + '_NAME'] = arrApp.title()
+            instance["name"] = arrApp.title()
     return settingsDict
 
 

--- a/src/utils/loadScripts.py
+++ b/src/utils/loadScripts.py
@@ -32,37 +32,46 @@ async def getArrInstanceName(settingsDict, arrApp, instance):
 
 
 async def getProtectedAndPrivateFromQbit(settingsDict):
-    # Returns two lists containing the hashes of Qbit that are either protected by tag, or are private trackers (if IGNORE_PRIVATE_TRACKERS is true)
+    # Returns two lists containing the hashes of qBittorrent torrents that are either protected by tag or marked as private.
     protectedDownloadIDs = []
     privateDowloadIDs = []
-    if settingsDict['QBITTORRENT_URL']:
-        # Fetch all torrents
-        qbitItems = await rest_get(settingsDict['QBITTORRENT_URL']+'/torrents/info',params={}, cookies=settingsDict['QBIT_COOKIE'])
-
+    if settingsDict.get('QBITTORRENT_INSTANCES'):
+        for instance in settingsDict['QBITTORRENT_INSTANCES']:
+            qbitItems = await rest_get(instance["url"]+'/torrents/info', params={}, cookies=instance.get("cookie"))
+            for qbitItem in qbitItems:
+                if settingsDict['NO_STALLED_REMOVAL_QBIT_TAG'] in qbitItem.get('tags', []):
+                    protectedDownloadIDs.append(str.upper(qbitItem['hash']))
+                if settingsDict['IGNORE_PRIVATE_TRACKERS']:
+                    if version.parse(settingsDict['QBIT_VERSION']) >= version.parse('5.1.0'):
+                        if qbitItem.get('private'):
+                            privateDowloadIDs.append(str.upper(qbitItem['hash']))
+                    else:
+                        qbitItemProperties = await rest_get(instance["url"]+'/torrents/properties', params={'hash': qbitItem['hash']}, cookies=instance.get("cookie"))
+                        if not qbitItemProperties:
+                            logger.error("Torrent %s not found on qBittorrent.", qbitItem['hash'])
+                            continue
+                        if qbitItemProperties.get('is_private', False):
+                            privateDowloadIDs.append(str.upper(qbitItem['hash']))
+                        qbitItem['private'] = qbitItemProperties.get('is_private', None)
+    elif settingsDict.get('QBITTORRENT_URL'):
+        qbitItems = await rest_get(settingsDict['QBITTORRENT_URL']+'/torrents/info', params={}, cookies=settingsDict['QBIT_COOKIE'])
         for qbitItem in qbitItems:
-            # Fetch protected torrents (by tag)
-            if settingsDict['NO_STALLED_REMOVAL_QBIT_TAG'] in qbitItem.get('tags'):
+            if settingsDict['NO_STALLED_REMOVAL_QBIT_TAG'] in qbitItem.get('tags', []):
                 protectedDownloadIDs.append(str.upper(qbitItem['hash']))
-                
-            # Fetch private torrents
-            if settingsDict['IGNORE_PRIVATE_TRACKERS']: 
+            if settingsDict['IGNORE_PRIVATE_TRACKERS']:
                 if version.parse(settingsDict['QBIT_VERSION']) >= version.parse('5.1.0'):
-                    if qbitItem['private']:
+                    if qbitItem.get('private'):
                         privateDowloadIDs.append(str.upper(qbitItem['hash']))
                 else:
-                    qbitItemProperties = await rest_get(settingsDict['QBITTORRENT_URL']+'/torrents/properties',params={'hash': qbitItem['hash']}, cookies=settingsDict['QBIT_COOKIE'])
+                    qbitItemProperties = await rest_get(settingsDict['QBITTORRENT_URL']+'/torrents/properties', params={'hash': qbitItem['hash']}, cookies=settingsDict['QBIT_COOKIE'])
                     if not qbitItemProperties:
-                        logger.error("Torrent %s not found on qBittorrent - potentially already removed whilst checking if torrent is private. Consider upgrading qBit to v5.1.0 or newer to avoid this problem.", qbitItem['hash'])
+                        logger.error("Torrent %s not found on qBittorrent.", qbitItem['hash'])
                         continue
                     if qbitItemProperties.get('is_private', False):
                         privateDowloadIDs.append(str.upper(qbitItem['hash']))
-                    qbitItem['private'] = qbitItemProperties.get('is_private', None) # Adds the is_private flag to qbitItem info for simplified logging
-
-        logger.debug('main/getProtectedAndPrivateFromQbit/qbitItems: %s', str([{"hash": str.upper(item["hash"]), "name": item["name"], "category": item["category"], "tags": item["tags"], "private": item.get("private", None)} for item in qbitItems]))
-    
+                    qbitItem['private'] = qbitItemProperties.get('is_private', None)
     logger.debug('main/getProtectedAndPrivateFromQbit/protectedDownloadIDs: %s', str(protectedDownloadIDs))
-    logger.debug('main/getProtectedAndPrivateFromQbit/privateDowloadIDs: %s', str(privateDowloadIDs))   
-
+    logger.debug('main/getProtectedAndPrivateFromQbit/privateDowloadIDs: %s', str(privateDowloadIDs))
     return protectedDownloadIDs, privateDowloadIDs
     
 def showWelcome():

--- a/src/utils/loadScripts.py
+++ b/src/utils/loadScripts.py
@@ -95,6 +95,8 @@ def showSettings(settingsDict):
     logger.info('%s | Removing slow downloads (%s)', str(settingsDict['REMOVE_SLOW']), 'REMOVE_SLOW')
     logger.info('%s | Removing stalled downloads (%s)', str(settingsDict['REMOVE_STALLED']), 'REMOVE_STALLED')
     logger.info('%s | Removing downloads belonging to unmonitored items (%s)', str(settingsDict['REMOVE_UNMONITORED']), 'REMOVE_UNMONITORED') 
+    logger.info('%s | Allow blocklisting of removed queue items (%s)', str(settingsDict['BLOCKLIST_REMOVED']), 'BLOCKLIST_REMOVED')
+    logger.info('%s | Move private tracker queue items to their post-import category (%s)', str(settingsDict['UPDATE_CATEGORY']), 'UPDATE_CATEGORY')
     for arr_type, RESCAN_SETTINGS in settingsDict['RUN_PERIODIC_RESCANS'].items():
         logger.info('%s/%s (%s) | Search missing/cutoff-unmet items. Max queries/list: %s. Min. days to re-search: %s (%s)', RESCAN_SETTINGS['MISSING'],  RESCAN_SETTINGS['CUTOFF_UNMET'], arr_type, RESCAN_SETTINGS['MAX_CONCURRENT_SCANS'], RESCAN_SETTINGS['MIN_DAYS_BEFORE_RESCAN'], 'RUN_PERIODIC_RESCANS') 
     logger.info('') 

--- a/src/utils/shared.py
+++ b/src/utils/shared.py
@@ -298,14 +298,49 @@ async def remove_download(
     deleted_downloads,
     removeFromClient,
 ):
-    # Removes downloads and creates log entry
+    """
+    Removes the queue item from the *Arr application. By default:
+      - 'removeFromClient' decides if the torrent/nzb is also removed from its download client
+      - 'addToBlocklist' decides if the item is blocklisted in *Arr
+      - If BLOCKLIST_REMOVED = False, items will never be blocklisted (even if addToBlocklist=True).
+      - If UPDATE_CATEGORY = True, we do removeFromClient=False + changeCategory=True
+    """
     logger.debug(
         "remove_download/deleted_downloads.dict IN: %s", str(deleted_downloads.dict)
     )
-    if affectedItem["downloadId"] not in deleted_downloads.dict:
-        # "schizophrenic" removal:
-        # Yes, the failed imports are removed from the -arr apps (so the removal kicks still in)
-        # But in the torrent client they are kept
+
+    # Only proceed if we haven't removed this downloadId before
+    if affectedItem["downloadId"] in deleted_downloads.dict:
+        logger.debug("remove_download: Skipping %s because already removed.", affectedItem["downloadId"])
+        return
+
+    # final_blocklist is true if:
+    #   (the job wants blocklist) AND (global BLOCKLIST_REMOVED is true)
+    final_blocklist = addToBlocklist and settingsDict["BLOCKLIST_REMOVED"]
+
+    if settingsDict["UPDATE_CATEGORY"]:
+        # If user wants to "update category," we:
+        # - do NOT remove from client
+        # - set changeCategory=True
+        params = {
+            "removeFromClient": False,
+            "blocklist": final_blocklist,
+            "skipRedownload": False,
+            "changeCategory": True
+        }
+        logger.info(
+            ">>> Updating category (rather than removing from client) for %s download: %s",
+            failType,
+            affectedItem["title"]
+        )
+        if final_blocklist:
+            logger.debug(">>> Also blocklisting this item in *Arr due to BLOCKLIST_REMOVED=True.")
+    else:
+        # Standard removal approach
+        params = {
+            "removeFromClient": removeFromClient,
+            "blocklist": final_blocklist,
+        }
         if removeFromClient:
             logger.info(">>> Removing %s download: %s", failType, affectedItem["title"])
         else:
@@ -315,23 +350,25 @@ async def remove_download(
                 affectedItem["title"],
             )
 
-        # Print out detailed removal messages (if any were added in the jobs)
-        if "removal_messages" in affectedItem:
-            for removal_message in affectedItem["removal_messages"]:
-                logger.info(removal_message)
+    # Print out any "removal_messages"
+    if "removal_messages" in affectedItem:
+        for removal_message in affectedItem["removal_messages"]:
+            logger.info(removal_message)
 
-        if not settingsDict["TEST_RUN"]:
-            await rest_delete(
-                f'{BASE_URL}/queue/{affectedItem["id"]}',
-                API_KEY,
-                {"removeFromClient": removeFromClient, "blocklist": addToBlocklist},
-            )
-        deleted_downloads.dict.append(affectedItem["downloadId"])
+    # Actually call *Arr, unless in test mode
+    if not settingsDict["TEST_RUN"]:
+        response = await rest_delete(
+            f'{BASE_URL}/queue/{affectedItem["id"]}',
+            API_KEY,
+            params,
+        )
+        logger.debug("remove_download - API response: %s", response)
 
+    # Record that we removed it
+    deleted_downloads.dict.append(affectedItem["downloadId"])
     logger.debug(
         "remove_download/deleted_downloads.dict OUT: %s", str(deleted_downloads.dict)
     )
-    return
 
 
 def errorDetails(NAME, error):

--- a/src/utils/shared.py
+++ b/src/utils/shared.py
@@ -1,8 +1,19 @@
 # Shared Functions
-import logging, verboselogs
+import logging
+try:
+    import verboselogs
+except ImportError:
+    verboselogs = None
 import asyncio
 import requests
-logger = verboselogs.VerboseLogger(__name__)
+if verboselogs:
+    logger = verboselogs.VerboseLogger(__name__)
+else:
+    logger = logging.getLogger(__name__)
+    if not hasattr(logger, 'verbose'):
+        def verbose(msg, *args, **kwargs):
+            logger.debug(msg, *args, **kwargs)
+        logger.verbose = verbose
 from src.utils.rest import rest_get, rest_delete, rest_post
 from src.utils.nest_functions import add_keys_nested_dict, nested_get
 import sys, os, traceback

--- a/src/utils/shared.py
+++ b/src/utils/shared.py
@@ -5,7 +5,10 @@ try:
 except ImportError:
     verboselogs = None
 import asyncio
-import requests
+try:
+    import requests
+except ImportError:
+    raise ImportError("The 'requests' package is required. Please install it using: pip install requests")
 if verboselogs:
     logger = verboselogs.VerboseLogger(__name__)
 else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Add the repository root directory (which contains the "src" folder) to sys.path.
+root_directory = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if root_directory not in sys.path:
+    sys.path.insert(0, root_directory)

--- a/tests/utils/remove_download/test_remove_download_1.py
+++ b/tests/utils/remove_download/test_remove_download_1.py
@@ -8,7 +8,11 @@ failType = "failed import"
 
 @pytest.mark.asyncio
 async def test_removal_with_removal_messages(monkeypatch, caplog):
-    settingsDict = {"TEST_RUN": True}
+    settingsDict = {
+        "TEST_RUN": True,
+        "BLOCKLIST_REMOVED": True, 
+        "UPDATE_CATEGORY": False  # new
+    }
     removeFromClient = True
     expected_removal_messages = {
         ">>> Removing failed import download: Sonarr Title 1",
@@ -30,7 +34,11 @@ async def test_removal_with_removal_messages(monkeypatch, caplog):
 
 @pytest.mark.asyncio
 async def test_schizophrenic_removal_with_removal_messages(monkeypatch, caplog):
-    settingsDict = {"TEST_RUN": True}
+    settingsDict = {
+        "TEST_RUN": True,
+        "BLOCKLIST_REMOVED": True, 
+        "UPDATE_CATEGORY": False  # new
+    }
     removeFromClient = False
     expected_removal_messages = {
         ">>> Removing failed import download (without removing from torrent client): Sonarr Title 1",


### PR DESCRIPTION
-Adds two new configuration options, UPDATE_CATEGORY and BLOCKLIST_REMOVED.

Update category will flag items removed from *arr apps as removeFromClient=false&changeCategory=true and defaults to false.

Blocklist removed implies whether items removed from the *arr queue should be blocklisted or not, defaults to true to retain prior behavior.

This modifies the logic of the remove_download function to be more modular. previously it always blocklisted and never supported updating to 'post-import category'.

Non-private torrents will still be removed from the torrent client and will not have their post-import category set.