### PR TITLE
Fix private torrent handling

### DIFF
--- a/src/settings/_download_clients_qBit.py
+++ b/src/settings/_download_clients_qBit.py
@@ -243,7 +243,7 @@ class QbitClient:
                 protected_downloads.append(qbit_item["hash"].upper())
 
             # Fetch private torrents
-            if not (self.settings.general.private_tracker_handling == "remove" or self.settings.general.public_tracker_handling == "remove"):
+            if self.settings.general.private_tracker_handling != "remove":
                 if version.parse(self.version) >= version.parse("5.0.0"):
                     if qbit_item.get("private"):
                         private_downloads.append(qbit_item["hash"].upper())


### PR DESCRIPTION
Just got myself 100 Hit&Runs ;D

Decluttar only listed the private torrents if:
```
not (
  self.settings.general.private_tracker_handling == "remove"
  or self.settings.general.public_tracker_handling == "remove"
)
```

With my configuration:
```
  private_tracker_handling: "obsolete_tag" # remove, skip, obsolete_tag
  public_tracker_handling: "remove" # remove, skip, obsolete_tag
```

This yields:
```
not (
  self.settings.general.private_tracker_handling == "remove"
  or self.settings.general.public_tracker_handling == "remove"
)
= not (false or true)
= not (true)
= false
```

So it did not enumerate the private torrents.

---

The setting for public handling seems irrelevant, so dropping, and then we can simplify the boolean logic.

---

I feel like the condition can create unexpected behaviour in an edge-case configuration anyways, so might want to consider not having any conditions at all:

```
  private_tracker_handling: "remove"
  public_tracker_handling: "skip"
```
 
In this case, we would handle all torrents, public and private, as `skip`. Because `private_tracker_handling: "remove"`, we never actually run the code that makes the distinction between a public and a private torrent.. so everything gets handled as public.

But I might be missing something, so leaving.