### PR TITLE
API Documentation Error: Queue deletion parameters incorrectly implemented

### DIFF
--- a/src/settings/_instances.py
+++ b/src/settings/_instances.py
@@ -327,7 +327,7 @@ class ArrInstance:
         )
         endpoint = f"{self.api_url}/queue/{queue_id}"
         headers = {"X-Api-Key": self.api_key}
-        json_payload = {"removeFromClient": True, "blocklist": blocklist}
+        query = {"removeFromClient": True, "blocklist": blocklist}
 
         # Send the request to remove the download from the queue
         response = await make_request(
@@ -335,7 +335,7 @@ class ArrInstance:
             endpoint,
             self.settings,
             headers=headers,
-            json=json_payload,
+            params=query,
         )
 
         # If the response is successful, return True, else return False


### PR DESCRIPTION
According to the Sonarr API documentation for v4 in the latest stable version, delete queue parameters should be passed as query parameters, not as JSON body parameters.
See more here: [https://sonarr.tv/docs/api/#/Queue/delete_api_v3_queue__id_](https://sonarr.tv/docs/api/#/Queue/delete_api_v3_queue__id_)