### PR TITLE
Support environment variables in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Looking to **upgrade from V1 to V2**? Look [here](#upgrading-from-v1-to-v2)
   - [Running in docker](#running-in-docker)
     - [Docker-compose with config file (recommended)](#docker-docker-compose-together-with-configyaml)
     - [Docker-compose only](#docker-specifying-all-settings-in-docker-compose)
+  - [Config file](#config-file)
 - [Upgrading from V1 to V2](#upgrading-from-v1-to-v2)
 - [Explanation of the settings](#explanation-of-the-settings)
   - [General](#general-settings)
@@ -288,6 +289,29 @@ services:
       # - $DOCKERDIR/appdata/decluttarr/logs:/app/logs # Uncomment to get logs in text file, too      
       # - $DATADIR/media:/media # If you use detect_deletions, add the identical mount paths that you use in your sonarr/radarr instances. This may be different to this example!
 ```
+
+### Config file
+
+Decluttarr V2 introduces a new configuration file that allows specifying
+configurations in YAML instead of through environment variables. It has the
+benefit of supporting multiple instances of the arrs and download clients. You
+can view [config_example.yaml](./config/config_example.yaml) for an example.
+
+The config file supports environment variables through the `!ENV` tag. For
+example, if you don't want to specify API keys statically, you can pass them in
+through environment variables and set your configuration to something like:
+
+```yaml
+instances:
+  sonarr:
+    - base_url: "http://sonarr.media"
+      api_key: !ENV SONARR_API_KEY
+
+  radarr:
+    - base_url: "http://radarr.media"
+      api_key: !ENV RADARR_API_KEY
+```
+
 ## Upgrading from V1 to V2
 
 Decluttarr v2 is a major update with a cleaner config format and powerful new features. Here's what changed and how to upgrade.

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,7 +9,7 @@ black==24.8.0
 pylint==3.3.3
 autoflake==2.3.1
 isort==5.13.2
-envyaml==1.10.211231
+pyyaml_env_tag==1.1
 demjson3==3.0.6
 ruff==0.11.11
 watchdog==6.0.0

--- a/src/settings/_user_config.py
+++ b/src/settings/_user_config.py
@@ -1,8 +1,11 @@
 import os
 from pathlib import Path
 import yaml
+from yaml_env_tag import add_env_tag
 
 from src.utils.log_setup import logger
+
+LOADER = add_env_tag(yaml.Loader)
 
 CONFIG_MAPPING = {
     "general": [
@@ -82,7 +85,7 @@ def _load_from_env() -> dict:
                 continue
 
             try:
-                parsed_value = yaml.safe_load(raw_value)
+                parsed_value = yaml.load(raw_value, Loader=LOADER)
                 parsed_value = _lowercase(parsed_value)
             except yaml.YAMLError as e:
                 logger.error(
@@ -116,7 +119,7 @@ def _load_from_yaml_file(settings):
     config_path = settings.paths.config_file
     try:
         with Path(config_path).open(encoding="utf-8") as file:
-            return yaml.safe_load(file) or {}
+            return yaml.load(file, Loader=LOADER) or {}
     except yaml.YAMLError as e:
         logger.error("Error reading YAML file: %s", e)
         return {}


### PR DESCRIPTION
Allows yaml files to include `!ENV` tags so that environment variables can be passed through to the config. E.g.

```yaml
instances:
  sonarr:
    - base_url: "http://sonarr.media"
      api_key: !ENV SONARR_API_KEY

  radarr:
    - base_url: "http://radarr.media"
      api_key: !ENV RADARR_API_KEY
```

Fixes #294 