### PR TITLE
[NEEDS CODE REVIEWER] Allow job configuration overrides on instance level

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ services:
       # DETECT_DELETIONS:
 
       # --- Instances ---
+      # Note: Each instance can optionally override global job settings using a 'jobs:' section
       SONARR: >
         - base_url: "http://sonarr1:8989"
           api_key: "$SONARR_API_KEY"
@@ -270,6 +271,14 @@ services:
       # RADARR: >
       #   - base_url: "http://radarr:7878"
       #     api_key: "$RADARR_API_KEY"
+      #
+      #   # Example: Second radarr instance with instance-specific job overrides
+      #   - base_url: "http://radarr-4k:7878"
+      #     api_key: "$RADARR_4K_API_KEY"
+      #     jobs:
+      #       remove_slow:
+      #         min_speed: 500        # Require faster speeds for 4K content
+      #       search_missing: false   # Don't auto-search on 4K instance
 
       # READARR: >
       #   - base_url: "http://readarr:8787"

--- a/config/config_example.yaml
+++ b/config/config_example.yaml
@@ -52,15 +52,43 @@ instances:
   sonarr:
     - base_url: "http://sonarr:8989"
       api_key: "xxxx"
+      # Optional: Override job settings for this specific instance
+      # Instance-level settings override global job settings
+      # jobs:
+      #   # Disable a globally-enabled job for this instance
+      #   remove_stalled: false
+      #
+      #   # Override specific parameters while inheriting others from global
+      #   remove_slow:
+      #     min_speed: 200  # Override min_speed, inherit max_strikes from global
+      #
+      #   # Enable a job disabled globally, with custom parameters
+      #   search_unmet_cutoff:
+      #     max_concurrent_searches: 2
+      #     min_days_between_searches: 14
+
   radarr:
     - base_url: "http://radarr:7878"
       api_key: "xxxx"
+      # This instance uses all global job settings (no overrides)
+
+    # Example: Second radarr instance (e.g., for 4K content)
+    # - base_url: "http://radarr-4k:7878"
+    #   api_key: "yyyy"
+    #   jobs:
+    #     # Different config for 4K instance
+    #     search_missing: false  # Don't auto-search on 4K
+    #     remove_slow:
+    #       min_speed: 500  # Require faster speeds for 4K content
+
   readarr:
     - base_url: "http://readarr:8787"
       api_key: "xxxx"
+
   lidarr:
     - base_url: "http://lidarr:8686"
       api_key: "xxxx"
+
   whisparr:
     - base_url: "http://whisparr:6969"
       api_key: "xxxx"

--- a/src/job_manager.py
+++ b/src/job_manager.py
@@ -90,14 +90,16 @@ class JobManager:
             self.arr.arr_type == "whisparr"
         ):  # Whisparr does not support this endpoint (yet?)
             return
-        if self.settings.jobs.search_missing.enabled:
+
+        if self.arr.jobs.search_missing.enabled:
             await SearchHandler(
                 arr=self.arr,
                 settings=self.settings,
                 missing_or_cutoff="missing",
                 job_name="search_missing",
             ).handle_search()
-        if self.settings.jobs.search_unmet_cutoff.enabled:
+
+        if self.arr.jobs.search_unmet_cutoff.enabled:
             await SearchHandler(
                 arr=self.arr,
                 settings=self.settings,
@@ -147,7 +149,8 @@ class JobManager:
         """
         Return a list of enabled removal job instances based on the provided settings.
 
-        Each job is included if the corresponding attribute exists and is truthy in settings.jobs.
+        Each job is included if the corresponding attribute exists and is truthy in
+        instance-specific jobs (arr.jobs) or global settings.jobs.
         """
         removal_job_classes = {
             "remove_bad_files": RemoveBadFiles,
@@ -163,7 +166,7 @@ class JobManager:
 
         jobs = []
         for removal_job_name, removal_job_class in removal_job_classes.items():
-            if getattr(self.settings.jobs, removal_job_name, False):
+            if getattr(self.arr.jobs, removal_job_name, False):
                 jobs.append(
                     removal_job_class(self.arr, self.settings, removal_job_name),
                 )

--- a/src/jobs/removal_job.py
+++ b/src/jobs/removal_job.py
@@ -21,7 +21,7 @@ class RemovalJob(ABC):
         self.arr = arr
         self.settings = settings
         self.job_name = job_name
-        self.job = getattr(self.settings.jobs, self.job_name)
+        self.job = getattr(self.arr.jobs, self.job_name)
         self.queue_manager = QueueManager(self.arr, self.settings)
         self.max_strikes = getattr(self.job, "max_strikes", None)
         if self.max_strikes:

--- a/src/jobs/search_handler.py
+++ b/src/jobs/search_handler.py
@@ -21,10 +21,10 @@ class SearchHandler:
             f"search_handler.py/_configure_search_target: Setting job & search label ({self.missing_or_cutoff})"
         )
         if self.missing_or_cutoff == "missing":
-            self.job = self.settings.jobs.search_missing
+            self.job = self.arr.jobs.search_missing
             self.search_target_label = f"missing {self.arr.detail_item_key}s"
         elif self.missing_or_cutoff == "cutoff":
-            self.job = self.settings.jobs.search_unmet_cutoff
+            self.job = self.arr.jobs.search_unmet_cutoff
             self.search_target_label = f"{self.arr.detail_item_key}s with unmet cutoff"
         else:
             error = f"Unknown search type: {self.missing_or_cutoff}"

--- a/src/settings/_instances.py
+++ b/src/settings/_instances.py
@@ -13,6 +13,7 @@ from src.settings._constants import (
     RefreshItemCommand,
     RefreshItemKey,
 )
+from src.settings._jobs import Jobs
 from src.utils.common import extract_json_from_response, make_request, wait_and_exit
 from src.utils.log_setup import logger
 
@@ -78,6 +79,8 @@ class ArrInstances(list):
             "refresh_item_key",
             "refresh_item_id_key",
             "refresh_item_command",
+            "_jobs_config",
+            "_jobs",
         }
 
         outputs = []
@@ -122,6 +125,7 @@ class ArrInstances(list):
                             arr_type=arr_type,
                             base_url=client_config["base_url"],
                             api_key=client_config["api_key"],
+                            jobs_config=client_config.get("jobs", {}),
                         ),
                     )
                 except KeyError as e:
@@ -135,7 +139,7 @@ class ArrInstance:
     version: str = None
     name: str = None
 
-    def __init__(self, settings, arr_type: str, base_url: str, api_key: str):
+    def __init__(self, settings, arr_type: str, base_url: str, api_key: str, jobs_config: dict | None = None):
         if not base_url:
             logger.error(f"Skipping {arr_type} client entry: 'base_url' is required.")
             error = f"{arr_type} client must have a 'base_url'."
@@ -162,6 +166,42 @@ class ArrInstance:
             self.refresh_item_key = getattr(RefreshItemKey, arr_type)
             self.refresh_item_id_key = self.refresh_item_key + "Id"
             self.refresh_item_command = getattr(RefreshItemCommand, arr_type)
+
+        # Store instance-specific jobs config for lazy initialization
+        self._jobs_config = jobs_config or {}
+        self._jobs = None
+
+    @property
+    def jobs(self):
+        """
+        Return merged jobs (instance overrides + global jobs).
+
+        Uses lazy initialization to avoid circular dependencies since Jobs
+        are created before ArrInstances during Settings initialization.
+        """
+        if self._jobs is None:
+            self._jobs = self._create_merged_jobs()
+        return self._jobs
+
+    def _create_merged_jobs(self):
+        """
+        Create a merged Jobs object with instance overrides applied.
+
+        Merging precedence: Instance overrides > Global jobs > Job defaults
+
+        Returns:
+            Jobs object with instance-specific overrides applied
+
+        """
+        if not self._jobs_config:
+            # No instance overrides, return global jobs
+            return self.settings.jobs
+
+        # Create merged jobs with instance overrides
+        return Jobs.create_with_overrides(
+            overrides=self._jobs_config,
+            global_jobs=self.settings.jobs,
+        )
 
     async def _check_ui_language(self):
         """Check if the UI language is set to English."""

--- a/src/settings/_jobs.py
+++ b/src/settings/_jobs.py
@@ -77,6 +77,102 @@ class Jobs:
         self._set_job_configs(config)
         del self.job_defaults
 
+    @classmethod
+    def create_with_overrides(cls, overrides, global_jobs):
+        """
+        Create a new Jobs instance with instance-level overrides applied.
+
+        This method creates a merged Jobs object where instance-specific settings
+        override global job settings while preserving unspecified parameters.
+
+        Args:
+            overrides: Dict of instance-specific job configurations
+            global_jobs: Global Jobs object to use as base
+
+        Returns:
+            Jobs object with instance overrides applied
+
+        """
+        # Create a new Jobs instance without calling __init__
+        merged = cls.__new__(cls)
+
+        # Copy all job objects from global jobs
+        for attr_name in dir(global_jobs):
+            if attr_name.startswith("_"):
+                continue
+            attr_value = getattr(global_jobs, attr_name)
+            if isinstance(attr_value, JobParams):
+                # Deep copy the job params
+                setattr(merged, attr_name, cls._deep_copy_job_params(attr_value))
+
+        # Apply instance overrides
+        for job_name, job_override_config in overrides.items():
+            if hasattr(merged, job_name):
+                merged._apply_override(job_name, job_override_config)
+            else:
+                logger.warning(
+                    f"Instance job override for unknown job '{job_name}' ignored. "
+                    f"Valid job names: {', '.join([name for name in dir(merged) if not name.startswith('_') and isinstance(getattr(merged, name), JobParams)])}",
+                )
+
+        return merged
+
+    @staticmethod
+    def _deep_copy_job_params(job_params):
+        """
+        Create a deep copy of a JobParams object.
+
+        Args:
+            job_params: JobParams object to copy
+
+        Returns:
+            New JobParams object with copied attributes
+
+        """
+        copied = JobParams()
+        for attr_name, attr_value in vars(job_params).items():
+            # Deep copy lists to avoid shared references
+            if isinstance(attr_value, list):
+                setattr(copied, attr_name, attr_value.copy())
+            else:
+                setattr(copied, attr_name, attr_value)
+        return copied
+
+    def _apply_override(self, job_name, override_config) -> None:
+        """
+        Apply instance-level override to a specific job.
+
+        Handles three configuration formats:
+        - None: Enable the job with existing parameters
+        - bool: Set enabled status
+        - dict: Merge parameters (instance values override global)
+
+        Args:
+            job_name: Name of the job to override
+            override_config: Override configuration (None, bool, or dict)
+
+        """
+        job = getattr(self, job_name)
+
+        if override_config is None:
+            # None means enable the job with existing parameters
+            job.enabled = True
+        elif isinstance(override_config, bool):
+            # Boolean directly sets enabled status
+            job.enabled = override_config
+        elif isinstance(override_config, dict):
+            # Dict means merge parameters
+            # Set enabled=True by default unless explicitly specified
+            if "enabled" in override_config:
+                job.enabled = override_config["enabled"]
+            else:
+                job.enabled = True
+
+            # Merge other parameters
+            for key, value in override_config.items():
+                if key != "enabled":
+                    setattr(job, key, value)
+
     def _set_job_defaults(self):
         self.remove_bad_files = JobParams(keep_archives=self.job_defaults.keep_archives)
         self.remove_done_seeding = JobParams(target_tags=self.job_defaults.target_tags)

--- a/tests/settings/test_instance_jobs.py
+++ b/tests/settings/test_instance_jobs.py
@@ -1,0 +1,379 @@
+"""Tests for instance-level job configuration overrides."""
+
+from unittest.mock import MagicMock
+
+from src.settings._instances import ArrInstance
+from src.settings._jobs import JobParams, Jobs
+from src.settings.settings import Settings
+
+
+def create_mock_settings():
+    """Create a mock Settings object with global jobs."""
+    settings = MagicMock()
+    settings.general = MagicMock()
+    settings.general.obsolete_tag = "Obsolete"
+
+    # Create global jobs
+    config = {
+        "job_defaults": {"max_strikes": 3, "min_speed": 100},
+        "jobs": {
+            "remove_stalled": {"max_strikes": 5},
+            "remove_slow": {"min_speed": 150, "max_strikes": 3},
+            "remove_failed_downloads": None,  # Enabled with defaults
+        },
+    }
+    settings.jobs = Jobs(config, settings)
+    return settings
+
+
+def test_instance_without_job_overrides_uses_global_jobs():
+    """Test that an instance without job overrides uses global jobs."""
+    settings = create_mock_settings()
+    arr = ArrInstance(settings, "sonarr", "http://test", "test_key", jobs_config={})
+
+    # Should return global jobs
+    assert arr.jobs is settings.jobs
+    assert arr.jobs.remove_stalled.max_strikes == 5
+    assert arr.jobs.remove_slow.min_speed == 150
+
+
+def test_instance_with_job_override_creates_merged_jobs():
+    """Test that instance with job overrides creates a merged Jobs object."""
+    settings = create_mock_settings()
+
+    jobs_config = {"remove_stalled": {"max_strikes": 10}}
+
+    arr = ArrInstance(
+        settings, "sonarr", "http://test", "test_key", jobs_config=jobs_config,
+    )
+
+    # Should create a new Jobs object, not the same as global
+    assert arr.jobs is not settings.jobs
+
+    # Instance override should be applied
+    assert arr.jobs.remove_stalled.max_strikes == 10
+
+    # Other jobs should inherit from global
+    assert arr.jobs.remove_slow.min_speed == 150
+    assert arr.jobs.remove_slow.max_strikes == 3
+
+
+def test_instance_can_disable_globally_enabled_job():
+    """Test that instance can disable a globally-enabled job."""
+    settings = create_mock_settings()
+
+    jobs_config = {"remove_failed_downloads": False}
+
+    arr = ArrInstance(
+        settings, "sonarr", "http://test", "test_key", jobs_config=jobs_config,
+    )
+
+    # Global job is enabled
+    assert settings.jobs.remove_failed_downloads.enabled is True
+
+    # Instance job should be disabled
+    assert arr.jobs.remove_failed_downloads.enabled is False
+
+
+def test_instance_can_enable_globally_disabled_job():
+    """Test that instance can enable a globally-disabled job."""
+    settings = create_mock_settings()
+
+    # search_missing is not in global config, so disabled
+    assert settings.jobs.search_missing.enabled is False
+
+    jobs_config = {"search_missing": {"max_concurrent_searches": 5}}
+
+    arr = ArrInstance(
+        settings, "sonarr", "http://test", "test_key", jobs_config=jobs_config,
+    )
+
+    # Instance should enable the job
+    assert arr.jobs.search_missing.enabled is True
+    assert arr.jobs.search_missing.max_concurrent_searches == 5
+
+
+def test_instance_partial_parameter_override():
+    """Test that instance can override specific parameters while inheriting others."""
+    settings = create_mock_settings()
+
+    # Global has min_speed=150, max_strikes=3
+    jobs_config = {"remove_slow": {"min_speed": 300}}  # Only override min_speed
+
+    arr = ArrInstance(
+        settings, "sonarr", "http://test", "test_key", jobs_config=jobs_config,
+    )
+
+    # min_speed should be overridden
+    assert arr.jobs.remove_slow.min_speed == 300
+
+    # max_strikes should be inherited from global
+    assert arr.jobs.remove_slow.max_strikes == 3
+
+
+def test_instance_override_with_none_enables_job():
+    """Test that instance override with None value enables the job."""
+    settings = create_mock_settings()
+
+    # search_unmet_cutoff is disabled globally
+    assert settings.jobs.search_unmet_cutoff.enabled is False
+
+    jobs_config = {"search_unmet_cutoff": None}  # Enable with defaults
+
+    arr = ArrInstance(
+        settings, "sonarr", "http://test", "test_key", jobs_config=jobs_config,
+    )
+
+    # Should be enabled
+    assert arr.jobs.search_unmet_cutoff.enabled is True
+
+
+def test_instance_override_with_bool_sets_enabled_status():
+    """Test that instance override with boolean sets enabled status."""
+    settings = create_mock_settings()
+
+    jobs_config = {
+        "remove_failed_downloads": False,  # Disable
+        "search_missing": True,  # Enable
+    }
+
+    arr = ArrInstance(
+        settings, "sonarr", "http://test", "test_key", jobs_config=jobs_config,
+    )
+
+    assert arr.jobs.remove_failed_downloads.enabled is False
+    assert arr.jobs.search_missing.enabled is True
+
+
+def test_multiple_instances_have_independent_job_configs():
+    """Test that multiple instances can have different job configurations."""
+    settings = create_mock_settings()
+
+    # Instance 1: Override remove_stalled
+    arr1 = ArrInstance(
+        settings,
+        "sonarr",
+        "http://sonarr1",
+        "key1",
+        jobs_config={"remove_stalled": {"max_strikes": 10}},
+    )
+
+    # Instance 2: Override remove_slow
+    arr2 = ArrInstance(
+        settings,
+        "sonarr",
+        "http://sonarr2",
+        "key2",
+        jobs_config={"remove_slow": {"min_speed": 500}},
+    )
+
+    # Instance 3: No overrides
+    arr3 = ArrInstance(settings, "radarr", "http://radarr", "key3")
+
+    # Each should have different configurations
+    assert arr1.jobs.remove_stalled.max_strikes == 10
+    assert arr1.jobs.remove_slow.min_speed == 150  # Global
+
+    assert arr2.jobs.remove_stalled.max_strikes == 5  # Global
+    assert arr2.jobs.remove_slow.min_speed == 500
+
+    assert arr3.jobs.remove_stalled.max_strikes == 5  # Global
+    assert arr3.jobs.remove_slow.min_speed == 150  # Global
+
+
+def test_jobs_create_with_overrides_deep_copies_job_params():
+    """Test that create_with_overrides deep copies JobParams to avoid shared state."""
+    settings = create_mock_settings()
+
+    # Create first instance with override
+    arr1 = ArrInstance(
+        settings,
+        "sonarr",
+        "http://sonarr1",
+        "key1",
+        jobs_config={"remove_stalled": {"max_strikes": 15}},
+    )
+
+    # Modify instance 1's job
+    arr1.jobs.remove_stalled.max_strikes = 20
+
+    # Create second instance - should not be affected by arr1 modification
+    arr2 = ArrInstance(
+        settings,
+        "sonarr",
+        "http://sonarr2",
+        "key2",
+        jobs_config={"remove_stalled": {"max_strikes": 15}},
+    )
+
+    # arr2 should have original override value, not arr1's modified value
+    assert arr2.jobs.remove_stalled.max_strikes == 15
+
+    # Global should also be unaffected
+    assert settings.jobs.remove_stalled.max_strikes == 5
+
+
+def test_jobs_create_with_overrides_handles_list_parameters():
+    """Test that list parameters are deep copied and not shared."""
+    settings = create_mock_settings()
+
+    # Configure global with message_patterns
+    settings.jobs.remove_failed_imports = JobParams(
+        enabled=True, message_patterns=["pattern1", "pattern2"],
+    )
+
+    # Instance overrides message_patterns
+    arr1 = ArrInstance(
+        settings,
+        "sonarr",
+        "http://sonarr1",
+        "key1",
+        jobs_config={
+            "remove_failed_imports": {"message_patterns": ["custom_pattern"]},
+        },
+    )
+
+    # Modify arr1's list
+    arr1.jobs.remove_failed_imports.message_patterns.append("added_pattern")
+
+    # Create another instance
+    arr2 = ArrInstance(
+        settings,
+        "sonarr",
+        "http://sonarr2",
+        "key2",
+        jobs_config={
+            "remove_failed_imports": {"message_patterns": ["custom_pattern"]},
+        },
+    )
+
+    # arr2 should not see arr1's modification
+    assert arr2.jobs.remove_failed_imports.message_patterns == ["custom_pattern"]
+
+    # Global should be unchanged
+    assert settings.jobs.remove_failed_imports.message_patterns == [
+        "pattern1",
+        "pattern2",
+    ]
+
+
+def test_instance_override_with_dict_enables_by_default():
+    """Test that dict override without 'enabled' key enables the job."""
+    settings = create_mock_settings()
+
+    # search_missing is disabled globally
+    assert settings.jobs.search_missing.enabled is False
+
+    # Override with dict but no 'enabled' key
+    jobs_config = {"search_missing": {"max_concurrent_searches": 10}}
+
+    arr = ArrInstance(
+        settings, "sonarr", "http://test", "test_key", jobs_config=jobs_config,
+    )
+
+    # Should be enabled by default when using dict override
+    assert arr.jobs.search_missing.enabled is True
+    assert arr.jobs.search_missing.max_concurrent_searches == 10
+
+
+def test_instance_override_with_dict_respects_explicit_enabled_false():
+    """Test that dict override with enabled=False disables the job."""
+    settings = create_mock_settings()
+
+    # remove_failed_downloads is enabled globally
+    assert settings.jobs.remove_failed_downloads.enabled is True
+
+    # Override with enabled=False
+    jobs_config = {"remove_failed_downloads": {"enabled": False}}
+
+    arr = ArrInstance(
+        settings, "sonarr", "http://test", "test_key", jobs_config=jobs_config,
+    )
+
+    # Should be disabled
+    assert arr.jobs.remove_failed_downloads.enabled is False
+
+
+def test_lazy_initialization_of_instance_jobs():
+    """Test that instance jobs are lazily initialized only when accessed."""
+    settings = create_mock_settings()
+
+    arr = ArrInstance(
+        settings,
+        "sonarr",
+        "http://test",
+        "test_key",
+        jobs_config={"remove_stalled": {"max_strikes": 10}},
+    )
+
+    # _jobs should be None before first access
+    assert arr._jobs is None
+
+    # Access jobs property
+    _ = arr.jobs
+
+    # _jobs should now be initialized
+    assert arr._jobs is not None
+
+    # Second access should return same object
+    jobs1 = arr.jobs
+    jobs2 = arr.jobs
+    assert jobs1 is jobs2
+
+
+def test_full_integration_with_settings(tmp_path, monkeypatch):
+    """Integration test with full Settings initialization."""
+    # Create a temporary config file
+    config_content = """
+general:
+  log_level: INFO
+  test_run: true
+  timer: 10
+
+job_defaults:
+  max_strikes: 3
+
+jobs:
+  remove_stalled:
+    max_strikes: 5
+  remove_slow:
+    min_speed: 100
+
+instances:
+  sonarr:
+    - base_url: "http://sonarr1:8989"
+      api_key: "test_key_1"
+      jobs:
+        remove_stalled:
+          max_strikes: 15
+        remove_slow: false
+
+    - base_url: "http://sonarr2:8989"
+      api_key: "test_key_2"
+      # No job overrides - uses global
+"""
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(config_content)
+
+    # Monkeypatch the Paths class to use our temporary config file
+    from src.settings._constants import Paths
+
+    monkeypatch.setattr(Paths, "config_file", str(config_path))
+
+    settings = Settings()
+
+    # Check that we have 2 sonarr instances
+    sonarr_instances = [arr for arr in settings.instances if arr.arr_type == "sonarr"]
+    assert len(sonarr_instances) == 2
+
+    sonarr1, sonarr2 = sonarr_instances
+
+    # Sonarr1 has overrides
+    assert sonarr1.jobs.remove_stalled.max_strikes == 15
+    assert sonarr1.jobs.remove_slow.enabled is False
+
+    # Sonarr2 uses global config
+    assert sonarr2.jobs.remove_stalled.max_strikes == 5
+    assert sonarr2.jobs.remove_slow.min_speed == 100
+    assert sonarr2.jobs.remove_slow.enabled is True

--- a/tests/settings/test_user_config_from_env.py
+++ b/tests/settings/test_user_config_from_env.py
@@ -134,3 +134,110 @@ def test_env_loading_parametrized(
         assert value == expected
     else:
         assert value == expected
+
+
+# ---- Test instance-level job overrides ----
+
+def test_instance_level_job_overrides_from_env():
+    """Test that instance-level job overrides work through environment variables."""
+    sonarr_with_jobs_yaml = textwrap.dedent(
+        """
+        - base_url: "http://sonarr1:8989"
+          api_key: "sonarr1_key"
+          jobs:
+            remove_stalled: false
+            remove_slow:
+              min_speed: 200
+              max_strikes: 5
+        - base_url: "http://sonarr2:8989"
+          api_key: "sonarr2_key"
+    """,
+    ).strip()
+
+    env = {
+        "SONARR": sonarr_with_jobs_yaml,
+        "REMOVE_STALLED": "true",  # Globally enabled
+        "REMOVE_SLOW": "min_speed: 100",  # Global config
+    }
+
+    with patch.dict(os.environ, env, clear=True):
+        config = _load_from_env()
+
+        # Check that the config was loaded
+        assert "instances" in config
+        assert "sonarr" in config["instances"]
+
+        sonarr_instances = config["instances"]["sonarr"]
+        assert len(sonarr_instances) == 2
+
+        # First instance has job overrides
+        sonarr1 = sonarr_instances[0]
+        assert sonarr1["base_url"] == "http://sonarr1:8989"
+        assert sonarr1["api_key"] == "sonarr1_key"
+        assert "jobs" in sonarr1
+        assert sonarr1["jobs"]["remove_stalled"] is False
+        assert sonarr1["jobs"]["remove_slow"]["min_speed"] == 200
+        assert sonarr1["jobs"]["remove_slow"]["max_strikes"] == 5
+
+        # Second instance has no job overrides
+        sonarr2 = sonarr_instances[1]
+        assert sonarr2["base_url"] == "http://sonarr2:8989"
+        assert sonarr2["api_key"] == "sonarr2_key"
+        assert "jobs" not in sonarr2
+
+
+def test_instance_job_overrides_integration_with_env():
+    """Integration test: instance job overrides work end-to-end with env vars."""
+    from src.settings.settings import Settings
+
+    radarr_with_jobs_yaml = textwrap.dedent(
+        """
+        - base_url: "http://radarr-1080p:7878"
+          api_key: "radarr_1080p_key"
+        - base_url: "http://radarr-4k:7878"
+          api_key: "radarr_4k_key"
+          jobs:
+            remove_slow:
+              min_speed: 500
+            search_missing: false
+    """,
+    ).strip()
+
+    env = {
+        "LOG_LEVEL": "INFO",
+        "TEST_RUN": "true",
+        "TIMER": "10",
+        "REMOVE_SLOW": "min_speed: 100\nmax_strikes: 3",
+        "SEARCH_MISSING": "true",
+        "RADARR": radarr_with_jobs_yaml,
+        "IN_DOCKER": "true",  # Mock being in Docker so env vars are used
+    }
+
+    with patch.dict(os.environ, env, clear=True):
+        # Create full Settings and verify instances
+        settings_full = Settings()
+
+        # Verify global jobs
+        assert settings_full.jobs.remove_slow.enabled is True
+        assert settings_full.jobs.remove_slow.min_speed == 100
+        assert settings_full.jobs.remove_slow.max_strikes == 3
+        assert settings_full.jobs.search_missing.enabled is True
+
+        radarr_instances = [
+            arr for arr in settings_full.instances if arr.arr_type == "radarr"
+        ]
+        assert len(radarr_instances) == 2
+
+        radarr_1080p, radarr_4k = radarr_instances
+
+        # 1080p instance uses global settings
+        assert radarr_1080p.base_url == "http://radarr-1080p:7878"
+        assert radarr_1080p.jobs.remove_slow.min_speed == 100
+        assert radarr_1080p.jobs.remove_slow.max_strikes == 3
+        assert radarr_1080p.jobs.search_missing.enabled is True
+
+        # 4K instance has overrides
+        assert radarr_4k.base_url == "http://radarr-4k:7878"
+        assert radarr_4k.jobs.remove_slow.min_speed == 500  # Overridden
+        assert radarr_4k.jobs.remove_slow.max_strikes == 3  # Inherited
+        assert radarr_4k.jobs.search_missing.enabled is False  # Overridden


### PR DESCRIPTION
Adds support for instance-level job configuration overrides, allowing different Sonarr/Radarr instances to have different job settings.

The change has been implemented with the following goals in mind:
* Avoid adding unnecessary complexity or new concepts to the config file.
* Hide the implementation from the jobs themselves, by handling the override mechanism in the settings module.

## Example
```yaml
job_defaults:
  max_strikes: 3

jobs:
  remove_slow:
    min_speed: 100
  search_unmet_cutoff:
    min_days_between_searches: 7
    max_concurrent_searches: 1

instances:
  sonarr:
    - base_url: "http://sonarr-hd:8989"
      api_key: "key1"
      # Uses global settings

    - base_url: "http://sonarr-4k:8989"
      api_key: "key2"
      jobs:
        remove_slow:
          min_speed: 500  # Override for this instance
        search_unmet_cutoff: false  # Disable for this instance
```

## AI Assistance
While the code itself has been written by hand, some of the documentation and unit tests were generated by Claude Code and then manually verified.