### PR TITLE
[NEEDS CODE REVIEWER] (time-out related) Fix detect_deletions disable gating and harden timeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Looking to **upgrade from V1 to V2**? Look [here](#upgrading-from-v1-to-v2)
     - [LOG_LEVEL](#log_level)
     - [TEST_RUN](#test_run)
     - [TIMER](#timer)
+    - [REQUEST_TIMEOUT](#request_timeout)
     - [SSL_VERIFICATION](#ssl_verification)
     - [IGNORE_DOWNLOAD_CLIENTS](#ignore_download_clients)
     - [PRIVATE_TRACKER_HANDLING / PUBLIC_TRACKER_HANDLING](#private_tracker_handling--public_tracker_handling)
@@ -193,6 +194,7 @@ services:
       LOG_LEVEL: INFO
       TEST_RUN: True
       TIMER: 10
+      # REQUEST_TIMEOUT: 15
       # IGNORED_DOWNLOAD_CLIENTS: >
       #   - emulerr
       # SSL_VERIFICATION: true
@@ -398,6 +400,13 @@ Configures the general behavior of the application (across all features)
 -   Type: Integer
 -   Unit: Minutes
 -   Is Mandatory: No (Defaults to 10)
+
+#### REQUEST_TIMEOUT
+
+-   Timeout used for HTTP/API requests to *arr and download clients
+-   Type: Integer or Float
+-   Unit: Seconds
+-   Is Mandatory: No (Defaults to 15)
 
 #### SSL_VERIFICATION
 

--- a/config/config_example.yaml
+++ b/config/config_example.yaml
@@ -2,6 +2,7 @@ general:
   log_level: INFO
   test_run: true
   timer: 10
+  # request_timeout: 15 # Optional: timeout for all HTTP/API calls in seconds
   # ignored_download_clients: ["emulerr"]
   # ssl_verification: false # Optional: Defaults to true
   # private_tracker_handling: "obsolete_tag" # remove, skip, obsolete_tag. Optional. Default: remove

--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ async def wait_next_run():
 async def main():
     await launch_steps(settings)
 
-    if settings.jobs.detect_deletions:
+    if settings.jobs.detect_deletions.enabled:
         await WatcherManager(settings).setup()
     # Start Cleaning
     while True:
@@ -60,7 +60,13 @@ async def main():
 
         # Refresh qBit Cookies (SABnzbd doesn't need cookie refresh)
         for qbit in settings.download_clients.qbittorrent:
-            await qbit.refresh_cookie()
+            try:
+                await qbit.refresh_cookie()
+            except Exception as err:  # noqa: BLE001
+                logger.error(
+                    f"Error while refreshing cookie for {qbit.name} ({qbit.base_url}): {err}",
+                    exc_info=True,
+                )
 
         # Run script for each instance
         for arr in settings.instances:
@@ -68,7 +74,13 @@ async def main():
             logger.verbose("")
 
         # Run download client jobs (these run independently of *arr instances)
-        await job_manager.run_download_client_jobs()
+        try:
+            await job_manager.run_download_client_jobs()
+        except Exception as err:  # noqa: BLE001
+            logger.error(
+                f"Error while running download-client jobs: {err}",
+                exc_info=True,
+            )
 
         # Wait for the next run
         await wait_next_run()

--- a/src/job_manager.py
+++ b/src/job_manager.py
@@ -1,4 +1,6 @@
 # Cleans the download queue
+import requests
+
 from src.jobs.remove_bad_files import RemoveBadFiles
 from src.jobs.remove_done_seeding import RemoveDoneSeeding
 from src.jobs.remove_failed_downloads import RemoveFailedDownloads
@@ -24,12 +26,25 @@ class JobManager:
     async def run_jobs(self, arr):
         self.arr = arr
         logger.info(f"*** Running jobs on {self.arr.name} ({self.arr.base_url}) ***")
-        await self.removal_jobs()
-        await self.search_jobs()
+        await self._run_arr_job_group("Removal Jobs", self.removal_jobs)
+        await self._run_arr_job_group("Search Jobs", self.search_jobs)
 
     async def run_download_client_jobs(self):
         """Run jobs that operate on download clients directly."""
-        if not await self._download_clients_connected():
+        try:
+            if not await self._download_clients_connected():
+                return None
+        except requests.exceptions.RequestException as err:
+            logger.error(
+                f"Download client connectivity check failed with request error: {err}",
+                exc_info=True,
+            )
+            return None
+        except Exception as err:  # noqa: BLE001
+            logger.error(
+                f"Download client connectivity check failed: {err}",
+                exc_info=True,
+            )
             return None
 
         items_detected = 0
@@ -56,7 +71,9 @@ class JobManager:
 
                 for download_client_job in download_client_jobs:
                     if download_client_job.job.enabled:
-                        items_detected += await download_client_job.run()
+                        items_detected += await self._run_download_client_job(
+                            download_client_job, client
+                        )
 
         return items_detected
 
@@ -142,6 +159,37 @@ class JobManager:
                 )
                 return False
         return True
+
+    async def _run_arr_job_group(self, label, job_runner):
+        """Run one ARR job group and keep the main loop alive on failures."""
+        try:
+            await job_runner()
+        except requests.exceptions.RequestException as err:
+            logger.error(
+                f"{label}: request error on {self.arr.name} ({self.arr.base_url}): {err}",
+                exc_info=True,
+            )
+        except Exception as err:  # noqa: BLE001
+            logger.error(
+                f"{label}: unexpected error on {self.arr.name} ({self.arr.base_url}): {err}",
+                exc_info=True,
+            )
+
+    async def _run_download_client_job(self, download_client_job, client):
+        """Run one download-client job and keep the loop alive on failures."""
+        try:
+            return await download_client_job.run()
+        except requests.exceptions.RequestException as err:
+            logger.error(
+                f"Download-client job '{download_client_job.job_name}' failed on {client.name} ({client.base_url}) due to request error: {err}",
+                exc_info=True,
+            )
+        except Exception as err:  # noqa: BLE001
+            logger.error(
+                f"Download-client job '{download_client_job.job_name}' failed on {client.name} ({client.base_url}): {err}",
+                exc_info=True,
+            )
+        return 0
 
     def _get_removal_jobs(self):
         """

--- a/src/settings/_general.py
+++ b/src/settings/_general.py
@@ -11,6 +11,7 @@ class General:
     log_level: str = "INFO"
     test_run: bool = False
     timer: float = 10.0
+    request_timeout: float = 15.0
     ssl_verification: bool = True
     ignored_download_clients: list = []
     private_tracker_handling: str = "remove"
@@ -23,6 +24,9 @@ class General:
         self.log_level = general_config.get("log_level", self.log_level.upper())
         self.test_run = general_config.get("test_run", self.test_run)
         self.timer = general_config.get("timer", self.timer)
+        self.request_timeout = general_config.get(
+            "request_timeout", self.request_timeout
+        )
         self.ssl_verification = general_config.get(
             "ssl_verification", self.ssl_verification
         )

--- a/src/settings/_jobs.py
+++ b/src/settings/_jobs.py
@@ -44,6 +44,10 @@ class JobParams:
             if getattr(self, attr) is None:
                 delattr(self, attr)
 
+    def __bool__(self):
+        """Allow direct truthiness checks to reflect whether this job is enabled."""
+        return bool(getattr(self, "enabled", False))
+
 
 class JobDefaults:
     """Represents default job settings."""

--- a/src/settings/_user_config.py
+++ b/src/settings/_user_config.py
@@ -13,6 +13,7 @@ CONFIG_MAPPING = {
         "LOG_LEVEL",
         "TEST_RUN",
         "TIMER",
+        "REQUEST_TIMEOUT",
         "SSL_VERIFICATION",
         "IGNORED_DOWNLOAD_CLIENTS",
         "PRIVATE_TRACKER_HANDLING",

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -42,7 +42,7 @@ async def make_request(
     method: str,
     endpoint: str,
     settings,
-    timeout: int = 15,
+    timeout: float | None = None,
     *,
     log_error=True,
     **kwargs,
@@ -51,6 +51,9 @@ async def make_request(
     A utility function to make HTTP requests (GET, POST, DELETE, PUT).
     """
     ignore_test_run = kwargs.pop("ignore_test_run", False)
+    request_timeout = timeout
+    if request_timeout is None:
+        request_timeout = getattr(getattr(settings, "general", None), "request_timeout", 15)
 
     if settings.general.test_run and not ignore_test_run:
         if method.lower() in ("put", "post", "delete"):
@@ -74,7 +77,7 @@ async def make_request(
             endpoint,
             **kwargs,
             verify=settings.general.ssl_verification,
-            timeout=timeout,
+            timeout=request_timeout,
         )
         response.raise_for_status()
         return response

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -53,7 +53,9 @@ async def make_request(
     ignore_test_run = kwargs.pop("ignore_test_run", False)
     request_timeout = timeout
     if request_timeout is None:
-        request_timeout = getattr(getattr(settings, "general", None), "request_timeout", 15)
+        request_timeout = getattr(
+            getattr(settings, "general", None), "request_timeout", 15
+        )
 
     if settings.general.test_run and not ignore_test_run:
         if method.lower() in ("put", "post", "delete"):

--- a/tests/jobs/test_job_manager.py
+++ b/tests/jobs/test_job_manager.py
@@ -40,10 +40,14 @@ async def test_run_download_client_jobs_handles_per_job_request_errors():
     failing_job = MagicMock()
     failing_job.job.enabled = True
     failing_job.job_name = "remove_done_seeding"
-    failing_job.run = AsyncMock(side_effect=requests.exceptions.ReadTimeout("timed out"))
+    failing_job.run = AsyncMock(
+        side_effect=requests.exceptions.ReadTimeout("timed out")
+    )
 
     with (
-        patch.object(manager, "_download_clients_connected", AsyncMock(return_value=True)),
+        patch.object(
+            manager, "_download_clients_connected", AsyncMock(return_value=True)
+        ),
         patch.object(
             manager,
             "_get_download_client_jobs_for_client",

--- a/tests/jobs/test_job_manager.py
+++ b/tests/jobs/test_job_manager.py
@@ -1,0 +1,73 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import requests
+
+from src.job_manager import JobManager
+
+
+@pytest.mark.asyncio
+async def test_run_jobs_keeps_running_when_one_group_raises_request_error():
+    settings = MagicMock()
+    manager = JobManager(settings)
+    arr = MagicMock()
+    arr.name = "Sonarr"
+    arr.base_url = "http://sonarr:8989"
+
+    with (
+        patch.object(
+            manager,
+            "removal_jobs",
+            AsyncMock(side_effect=requests.exceptions.ReadTimeout("timed out")),
+        ),
+        patch.object(manager, "search_jobs", AsyncMock()) as search_jobs,
+    ):
+        await manager.run_jobs(arr)
+
+    search_jobs.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_download_client_jobs_handles_per_job_request_errors():
+    settings = MagicMock()
+    client = MagicMock()
+    client.name = "qBittorrent"
+    client.base_url = "http://qbittorrent:8080"
+    settings.download_clients.qbittorrent = [client]
+    settings.download_clients.sabnzbd = []
+
+    manager = JobManager(settings)
+    failing_job = MagicMock()
+    failing_job.job.enabled = True
+    failing_job.job_name = "remove_done_seeding"
+    failing_job.run = AsyncMock(side_effect=requests.exceptions.ReadTimeout("timed out"))
+
+    with (
+        patch.object(manager, "_download_clients_connected", AsyncMock(return_value=True)),
+        patch.object(
+            manager,
+            "_get_download_client_jobs_for_client",
+            MagicMock(return_value=[failing_job]),
+        ),
+    ):
+        result = await manager.run_download_client_jobs()
+
+    assert result == 0
+    failing_job.run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_download_client_jobs_handles_connection_check_request_errors():
+    settings = MagicMock()
+    settings.download_clients.qbittorrent = []
+    settings.download_clients.sabnzbd = []
+    manager = JobManager(settings)
+
+    with patch.object(
+        manager,
+        "_download_clients_connected",
+        AsyncMock(side_effect=requests.exceptions.ReadTimeout("timed out")),
+    ):
+        result = await manager.run_download_client_jobs()
+
+    assert result is None

--- a/tests/settings/test_general.py
+++ b/tests/settings/test_general.py
@@ -1,0 +1,13 @@
+from src.settings._general import General
+
+
+def test_request_timeout_defaults_to_15_seconds():
+    general = General({})
+
+    assert general.request_timeout == 15.0
+
+
+def test_request_timeout_accepts_numeric_strings():
+    general = General({"general": {"request_timeout": "42"}})
+
+    assert general.request_timeout == 42.0

--- a/tests/settings/test_jobs.py
+++ b/tests/settings/test_jobs.py
@@ -1,0 +1,10 @@
+from src.settings._jobs import JobParams
+
+
+def test_job_params_truthiness_is_false_by_default():
+    assert not JobParams()
+
+
+def test_job_params_truthiness_reflects_enabled_flag():
+    assert JobParams(enabled=True)
+    assert not JobParams(enabled=False)

--- a/tests/settings/test_user_config_from_env.py
+++ b/tests/settings/test_user_config_from_env.py
@@ -14,6 +14,7 @@ from src.settings._user_config import _load_from_env
 # Single values as plain strings (not YAML block strings)
 LOG_LEVEL_VALUE = "VERBOSE"
 TIMER_VALUE = "10"
+REQUEST_TIMEOUT_VALUE = "35"
 SSL_VERIFICATION_VALUE = "true"
 
 # List
@@ -79,6 +80,7 @@ def fixture_env_vars():
     env = {
         "LOG_LEVEL": LOG_LEVEL_VALUE,
         "TIMER": TIMER_VALUE,
+        "REQUEST_TIMEOUT": REQUEST_TIMEOUT_VALUE,
         "SSL_VERIFICATION": SSL_VERIFICATION_VALUE,
         "IGNORED_DOWNLOAD_CLIENTS": ignored_download_clients_yaml,
         "REMOVE_BAD_FILES": remove_bad_files_yaml,
@@ -107,6 +109,7 @@ qbit_expected = yaml.safe_load(qbit_yaml)
     [
         ("general", "log_level", LOG_LEVEL_VALUE),
         ("general", "timer", int(TIMER_VALUE)),
+        ("general", "request_timeout", int(REQUEST_TIMEOUT_VALUE)),
         ("general", "ssl_verification", True),
         (
             "general",

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -1,0 +1,43 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.utils.common import make_request
+
+
+@pytest.mark.asyncio
+async def test_make_request_uses_general_request_timeout_by_default():
+    settings = MagicMock()
+    settings.general.test_run = False
+    settings.general.ssl_verification = True
+    settings.general.request_timeout = 42
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("src.utils.common.asyncio.to_thread", new_callable=AsyncMock) as to_thread:
+        to_thread.return_value = mock_response
+
+        await make_request("get", "http://example.com/api", settings)
+
+    assert to_thread.await_count == 1
+    assert to_thread.await_args.kwargs["timeout"] == 42
+
+
+@pytest.mark.asyncio
+async def test_make_request_allows_explicit_timeout_override():
+    settings = MagicMock()
+    settings.general.test_run = False
+    settings.general.ssl_verification = True
+    settings.general.request_timeout = 42
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("src.utils.common.asyncio.to_thread", new_callable=AsyncMock) as to_thread:
+        to_thread.return_value = mock_response
+
+        await make_request("get", "http://example.com/api", settings, timeout=7)
+
+    assert to_thread.await_count == 1
+    assert to_thread.await_args.kwargs["timeout"] == 7

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -15,7 +15,9 @@ async def test_make_request_uses_general_request_timeout_by_default():
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
 
-    with patch("src.utils.common.asyncio.to_thread", new_callable=AsyncMock) as to_thread:
+    with patch(
+        "src.utils.common.asyncio.to_thread", new_callable=AsyncMock
+    ) as to_thread:
         to_thread.return_value = mock_response
 
         await make_request("get", "http://example.com/api", settings)
@@ -34,7 +36,9 @@ async def test_make_request_allows_explicit_timeout_override():
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
 
-    with patch("src.utils.common.asyncio.to_thread", new_callable=AsyncMock) as to_thread:
+    with patch(
+        "src.utils.common.asyncio.to_thread", new_callable=AsyncMock
+    ) as to_thread:
         to_thread.return_value = mock_response
 
         await make_request("get", "http://example.com/api", settings, timeout=7)


### PR DESCRIPTION
## Summary
- Fix `detect_deletions` gating so disabled jobs do not start folder watchers (`main.py` now checks `.enabled`).
- Add `JobParams.__bool__` so object truthiness consistently reflects job enabled state.
- Add configurable global HTTP timeout via `general.request_timeout` (and env `REQUEST_TIMEOUT`) instead of a hardcoded 15s timeout in `make_request`.
- Add runtime error boundaries so request failures in ARR/download-client job groups are logged and the main loop keeps running instead of crashing.
- Update docs/example config for `request_timeout` and add regression tests.

## Why
- Closes #329: `detect_deletions` was starting folder watchers even when disabled; `main.py` now checks `.enabled`.
- Fixes #317: makes the HTTP timeout tunable via `request_timeout` (env `REQUEST_TIMEOUT`) and adds per-group error boundaries so one request failure no longer terminates the full run loop.

## Validation
- `python3 -m pytest -q`
- `python3 -m pylint main.py src/job_manager.py src/utils/common.py src/settings/_general.py src/settings/_jobs.py src/settings/_user_config.py tests/jobs/test_job_manager.py tests/settings/test_general.py tests/settings/test_jobs.py tests/utils/test_common.py`
