### PR TITLE
Add tag-only handoff mode with deferred ARR follow-up

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
       - '**'
     paths:
       - 'src/**'
+      - 'main.py'
       - 'docker/**'
       - '.github/workflows/build.yml'
   pull_request:
@@ -13,6 +14,7 @@ on:
       - '**'
     paths:
       - 'src/**'
+      - 'main.py'
       - 'docker/**'
       - '.github/workflows/build.yml'
   workflow_dispatch:
@@ -21,7 +23,7 @@ on:
       - '**'
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -86,11 +88,17 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Store short Commit ID in env variable
         id: vars
@@ -126,20 +134,20 @@ jobs:
 
       - name: Build, Tag, and Push Docker Image
         env:
-          IMAGE_NAME: ghcr.io/${{ env.REPO_OWNER }}/decluttarr
+          GHCR_IMAGE_NAME: ghcr.io/${{ env.REPO_OWNER }}/decluttarr
+          DOCKERHUB_IMAGE_NAME: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/decluttarr
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
         run: |
           BRANCH_NAME="${{ github.ref_name }}"
-          TAG_LATEST=""
+          TAG_ARGS="-t ${GHCR_IMAGE_NAME}:${IMAGE_TAG} -t ${DOCKERHUB_IMAGE_NAME}:${IMAGE_TAG}"
           if [[ "$BRANCH_NAME" == "latest" ]]; then
-            TAG_LATEST="-t $IMAGE_NAME:latest"
+            TAG_ARGS="$TAG_ARGS -t ${GHCR_IMAGE_NAME}:latest -t ${DOCKERHUB_IMAGE_NAME}:latest"
           fi
 
           docker buildx build \
             --platform linux/amd64,linux/arm64 -f docker/Dockerfile . \
             --progress plain \
-            -t $IMAGE_NAME:$IMAGE_TAG \
-            $TAG_LATEST \
+            $TAG_ARGS \
             --label com.decluttarr.version=$IMAGE_TAG \
             --label com.decluttarr.commit=$SHORT_COMMIT_ID \
             --build-arg IMAGE_TAG=$IMAGE_TAG \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,14 @@ name: Test, Build, Deploy
 on:
   push:
     branches:
-      - '*'
+      - '**'
     paths:
       - 'src/**'
       - 'docker/**'
       - '.github/workflows/build.yml'
   pull_request:
     branches:
-      - '*'
+      - '**'
     paths:
       - 'src/**'
       - 'docker/**'
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
   create:
     branches:
-      - '*'
+      - '**'
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,10 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   validate-branch-name:
     runs-on: ubuntu-latest
@@ -101,8 +105,15 @@ jobs:
           else
             IMAGE_TAG=$BRANCH_NAME
           fi
-          # Convert IMAGE_TAG to lowercase
-          IMAGE_TAG=$(echo $IMAGE_TAG | tr '[:upper:]' '[:lower:]')
+
+          # Normalize tags to Docker-compatible values so feature/* branches can be published.
+          IMAGE_TAG=$(echo "$IMAGE_TAG" | tr '[:upper:]' '[:lower:]')
+          IMAGE_TAG=$(echo "$IMAGE_TAG" | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/^[.]+//; s/[.]+$//; s/-{2,}/-/g')
+          IMAGE_TAG="${IMAGE_TAG:0:120}"
+          if [[ -z "$IMAGE_TAG" ]]; then
+            IMAGE_TAG="branch-${SHORT_COMMIT_ID}"
+          fi
+
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
           
           # Convert repository owner to lowercase

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,6 @@ on:
       - '.github/workflows/build.yml'
   workflow_dispatch:
   create:
-    branches:
-      - '**'
 
 permissions:
   contents: write
@@ -38,11 +36,11 @@ jobs:
           BRANCH_NAME="${{ github.ref_name }}"
           if [[ "$BRANCH_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Branch name '$BRANCH_NAME' is not allowed. Branch names using versioning names like 'v1.2.3' are prohibited."
-            echo "valid_branch_name=false" >> $GITHUB_OUTPUT
+            echo "valid_branch_name=false" >> "$GITHUB_OUTPUT"
             exit 1
           else
             echo "Branch name '$BRANCH_NAME' is valid."
-            echo "valid_branch_name=true" >> $GITHUB_OUTPUT
+            echo "valid_branch_name=true" >> "$GITHUB_OUTPUT"
           fi
 
   unit-tests:
@@ -52,7 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10.13'
       - name: Install testing dependencies
@@ -104,7 +102,7 @@ jobs:
         id: vars
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.sha }})
-          echo "SHORT_COMMIT_ID=$calculatedSha" >> $GITHUB_ENV
+          echo "SHORT_COMMIT_ID=$calculatedSha" >> "$GITHUB_ENV"
 
       - name: Determine Docker image tag
         id: determine_tag
@@ -113,9 +111,9 @@ jobs:
           if [[ "$BRANCH_NAME" == "dev" ]]; then
             IMAGE_TAG="dev"
           elif [[ "$BRANCH_NAME" == "latest" ]]; then
-            IMAGE_TAG=${{ steps.setversion.outputs.new_tag }}
+            IMAGE_TAG="${{ steps.setversion.outputs.new_tag }}"
           else
-            IMAGE_TAG=$BRANCH_NAME
+            IMAGE_TAG="$BRANCH_NAME"
           fi
 
           # Normalize tags to Docker-compatible values so feature/* branches can be published.
@@ -126,11 +124,11 @@ jobs:
             IMAGE_TAG="branch-${SHORT_COMMIT_ID}"
           fi
 
-          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+          echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_ENV"
           
           # Convert repository owner to lowercase
-          REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')
-          echo "REPO_OWNER=$REPO_OWNER" >> $GITHUB_ENV
+          REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "REPO_OWNER=$REPO_OWNER" >> "$GITHUB_ENV"
 
       - name: Build, Tag, and Push Docker Image
         env:
@@ -139,19 +137,19 @@ jobs:
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
         run: |
           BRANCH_NAME="${{ github.ref_name }}"
-          TAG_ARGS="-t ${GHCR_IMAGE_NAME}:${IMAGE_TAG} -t ${DOCKERHUB_IMAGE_NAME}:${IMAGE_TAG}"
+          TAG_ARGS=(-t "${GHCR_IMAGE_NAME}:${IMAGE_TAG}" -t "${DOCKERHUB_IMAGE_NAME}:${IMAGE_TAG}")
           if [[ "$BRANCH_NAME" == "latest" ]]; then
-            TAG_ARGS="$TAG_ARGS -t ${GHCR_IMAGE_NAME}:latest -t ${DOCKERHUB_IMAGE_NAME}:latest"
+            TAG_ARGS+=(-t "${GHCR_IMAGE_NAME}:latest" -t "${DOCKERHUB_IMAGE_NAME}:latest")
           fi
 
           docker buildx build \
             --platform linux/amd64,linux/arm64 -f docker/Dockerfile . \
             --progress plain \
-            $TAG_ARGS \
-            --label com.decluttarr.version=$IMAGE_TAG \
-            --label com.decluttarr.commit=$SHORT_COMMIT_ID \
-            --build-arg IMAGE_TAG=$IMAGE_TAG \
-            --build-arg SHORT_COMMIT_ID=$SHORT_COMMIT_ID \
+            "${TAG_ARGS[@]}" \
+            --label "com.decluttarr.version=$IMAGE_TAG" \
+            --label "com.decluttarr.commit=$SHORT_COMMIT_ID" \
+            --build-arg "IMAGE_TAG=$IMAGE_TAG" \
+            --build-arg "SHORT_COMMIT_ID=$SHORT_COMMIT_ID" \
             --push
 
   docker-image-clean-up:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,15 @@ on:
       - '*'
     paths:
       - 'src/**'
+      - 'docker/**'
+      - '.github/workflows/build.yml'
   pull_request:
     branches:
       - '*'
     paths:
       - 'src/**'
+      - 'docker/**'
+      - '.github/workflows/build.yml'
   workflow_dispatch:
   create:
     branches:
@@ -60,7 +64,7 @@ jobs:
   build:
     needs: unit-tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/delete.yml
+++ b/.github/workflows/delete.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - '*' 
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   delete-branch-docker-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/delete.yml
+++ b/.github/workflows/delete.yml
@@ -3,7 +3,7 @@ name: Branch Delete
 on:
   delete:
     branches:
-      - '*' 
+      - '**'
 
 permissions:
   contents: read
@@ -26,8 +26,10 @@ jobs:
         run: |
           # Use jq to extract the branch name from the event payload
           BRANCH=$(cat ${{ github.event_path }} | jq --raw-output '.ref' | sed 's/refs\/heads\///')
-          # Convert branch name to lowercase
+          # Normalize to the same Docker-safe tag format used by build.yml
           BRANCH_NAME=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]')
+          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/^[.]+//; s/[.]+$//; s/-{2,}/-/g')
+          BRANCH_NAME="${BRANCH_NAME:0:120}"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
       - name: Remove Docker image

--- a/.github/workflows/delete.yml
+++ b/.github/workflows/delete.yml
@@ -2,8 +2,6 @@
 name: Branch Delete
 on:
   delete:
-    branches:
-      - '**'
 
 permissions:
   contents: read
@@ -15,7 +13,7 @@ jobs:
 
     steps:
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -25,12 +23,12 @@ jobs:
         id: get_branch_name
         run: |
           # Use jq to extract the branch name from the event payload
-          BRANCH=$(cat ${{ github.event_path }} | jq --raw-output '.ref' | sed 's/refs\/heads\///')
+          BRANCH=$(jq --raw-output '.ref' "${{ github.event_path }}" | sed 's/refs\/heads\///')
           # Normalize to the same Docker-safe tag format used by build.yml
           BRANCH_NAME=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]')
           BRANCH_NAME=$(echo "$BRANCH_NAME" | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/^[.]+//; s/[.]+$//; s/-{2,}/-/g')
           BRANCH_NAME="${BRANCH_NAME:0:120}"
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
 
       - name: Remove Docker image
         uses: dataaxiom/ghcr-cleanup-action@v1.0.8

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Looking to **upgrade from V1 to V2**? Look [here](#upgrading-from-v1-to-v2)
     - [MAX_STRIKES](#max_strikes)
     - [MIN_DAYS_BETWEEN_SEARCHES](#min_days_between_searches)
     - [MAX_CONCURRENT_SEARCHES](#max_concurrent_searches)
+    - [ACTION_MODE](#action_mode)
+    - [HANDOFF_TAG](#handoff_tag)
+    - [DEFERRED_ARR_FOLLOWUP](#deferred_arr_followup)
+    - [FOLLOWUP_TRIGGER](#followup_trigger)
   - [Jobs](#jobs)
     - [REMOVE_BAD_FILES](#remove_bad_files)
     - [REMOVE_FAILED_DOWNLOADS](#remove_failed_downloads)
@@ -207,6 +211,10 @@ services:
       # max_strikes: 3
       # MIN_DAYS_BETWEEN_SEARCHES: 7
       # MAX_CONCURRENT_SEARCHES: 3
+      # ACTION_MODE: "remove" # remove, skip, tag_only (ARR-removal jobs)
+      # HANDOFF_TAG: "cleanup-ready"
+      # DEFERRED_ARR_FOLLOWUP: false
+      # FOLLOWUP_TRIGGER: "on_download_removed"
 
       # # --- Jobs (short notation) ---
       # If you want to go with the most basic settings, you can just turn them all on:
@@ -246,6 +254,11 @@ services:
       #   max_strikes: 3
       # REMOVE_MISSING_FILES: True
       # REMOVE_ORPHANS: True
+      # REMOVE_ORPHANS: |
+      #   action_mode: "tag_only"
+      #   handoff_tag: "cleanup-ready"
+      #   deferred_arr_followup: true
+      #   followup_trigger: "on_download_removed"
       # REMOVE_SLOW: |
       #   min_speed: 100
       #   max_strikes: 3
@@ -479,9 +492,54 @@ If a job has the same settings configured on job-level, the job-level settings w
 -   Permissible Values: Any number
 -   Is Mandatory: No (Defaults to 3)
 
+#### ACTION_MODE
+
+-   Optional default for ARR-removal jobs (`remove_bad_files`, `remove_failed_downloads`, `remove_failed_imports`, `remove_metadata_missing`, `remove_missing_files`, `remove_orphans`, `remove_slow`, `remove_stalled`, `remove_unmonitored`)
+-   Defines how Decluttarr should act when a matching item is found
+    -   `remove`: Existing/default behavior (`remove`, `skip`, `obsolete_tag`) determined by private/public handling
+    -   `skip`: Do not take removal/tag action
+    -   `tag_only`: Apply a handoff tag and do not remove from download client directly
+-   Type: String
+-   Permissible Values: remove, skip, tag_only
+-   Is Mandatory: No (Defaults to remove)
+
+#### HANDOFF_TAG
+
+-   Optional default tag used when `action_mode` is set to `tag_only`
+-   If empty, Decluttarr falls back to `OBSOLETE_TAG`
+-   Type: String
+-   Permissible Values: Any
+-   Is Mandatory: No (Defaults to empty -> fallback to OBSOLETE_TAG)
+
+#### DEFERRED_ARR_FOLLOWUP
+
+-   Optional default for `tag_only` workflows
+-   If enabled, Decluttarr waits until the tagged torrent is no longer present in the download client, then triggers ARR queue follow-up actions for the matching item
+-   Type: Boolean
+-   Permissible Values: True, False
+-   Is Mandatory: No (Defaults to False)
+
+#### FOLLOWUP_TRIGGER
+
+-   Optional default trigger used together with `deferred_arr_followup`
+-   Supported trigger(s):
+    -   `on_download_removed`: follow-up is triggered when Decluttarr detects the download hash is gone from qBittorrent
+-   Type: String
+-   Permissible Values: on_download_removed
+-   Is Mandatory: No (Defaults to on_download_removed)
+
 ### **Jobs**
 
 This is the interesting section. It defines which job you want decluttarr to run for you.
+
+For ARR-removal jobs (`remove_bad_files`, `remove_failed_downloads`, `remove_failed_imports`, `remove_metadata_missing`, `remove_missing_files`, `remove_orphans`, `remove_slow`, `remove_stalled`, `remove_unmonitored`), you can optionally set the following keys per job:
+
+- `action_mode`
+- `handoff_tag`
+- `deferred_arr_followup`
+- `followup_trigger`
+
+When omitted on job-level, Job Defaults are used.
 
 #### REMOVE_BAD_FILES
 

--- a/config/config_example.yaml
+++ b/config/config_example.yaml
@@ -13,6 +13,10 @@ job_defaults:
   max_strikes: 3
   min_days_between_searches: 7
   max_concurrent_searches: 3
+  # action_mode: "remove" # Optional for ARR-removal jobs: remove, skip, tag_only
+  # handoff_tag: "cleanup-ready" # Optional: used when action_mode=tag_only
+  # deferred_arr_followup: false # Optional: run ARR follow-up after external removal is detected
+  # followup_trigger: "on_download_removed" # Optional: currently supported trigger
 
 jobs:
   remove_bad_files:
@@ -35,6 +39,10 @@ jobs:
     # max_strikes: 3
   remove_missing_files:
   remove_orphans:
+    # action_mode: "tag_only"
+    # handoff_tag: "cleanup-ready"
+    # deferred_arr_followup: true
+    # followup_trigger: "on_download_removed"
   remove_slow:
     # min_speed: 100
     # max_strikes: 3

--- a/src/jobs/removal_handler.py
+++ b/src/jobs/removal_handler.py
@@ -1,18 +1,30 @@
 from src.utils.log_setup import logger
 
+VALID_ACTION_MODES = {"remove", "skip", "tag_only"}
+VALID_FOLLOWUP_TRIGGERS = {"on_download_removed"}
+
 
 class RemovalHandler:
     def __init__(self, arr, settings, job_name):
         self.arr = arr
         self.settings = settings
         self.job_name = job_name
+        self.job = getattr(self.settings.jobs, self.job_name)
 
     async def remove_downloads(self, affected_downloads, blocklist):
+        action_mode = self._get_action_mode()
+        deferred_arr_followup = self._is_deferred_arr_followup()
+        followup_trigger = self._get_followup_trigger()
+        handoff_tag = self._get_handoff_tag()
+
         for download_id in list(affected_downloads.keys()):
 
             affected_download = affected_downloads[download_id]
-            handling_method = await self._get_handling_method(
+            tracker_handling_method = await self._get_handling_method(
                 download_id, affected_download
+            )
+            handling_method = self._resolve_effective_handling_method(
+                action_mode, tracker_handling_method
             )
 
             if download_id in self.arr.tracker.deleted or handling_method == "skip":
@@ -23,6 +35,41 @@ class RemovalHandler:
                 await self._remove_download(affected_download, download_id, blocklist)
             elif handling_method == "obsolete_tag":
                 await self._tag_as_obsolete(affected_download, download_id)
+            elif handling_method == "tag_only":
+                if not self._supports_tag_handoff(affected_download):
+                    logger.warning(
+                        "Job '%s' configured with action_mode='tag_only' but this download cannot be tagged for handoff "
+                        "(protocol/client unsupported or missing qBittorrent mapping). Skipping download: %s",
+                        self.job_name,
+                        affected_download.get("title", download_id),
+                    )
+                    del affected_downloads[download_id]
+                    continue
+
+                await self._tag_with_custom_tag(
+                    affected_download,
+                    download_id,
+                    handoff_tag,
+                )
+
+                if deferred_arr_followup and followup_trigger == "on_download_removed":
+                    if await self._download_exists_in_client(download_id, affected_download):
+                        logger.debug(
+                            "Job '%s' deferred ARR follow-up pending removal from download client: %s",
+                            self.job_name,
+                            affected_download.get("title", download_id),
+                        )
+                    else:
+                        logger.info(
+                            "Job '%s' detected handoff-tagged download removed from client; triggering deferred ARR follow-up: %s",
+                            self.job_name,
+                            affected_download.get("title", download_id),
+                        )
+                        await self._remove_download(
+                            affected_download,
+                            download_id,
+                            blocklist,
+                        )
 
             # Print out detailed removal messages (if any)
             if "removal_messages" in affected_download:
@@ -48,6 +95,22 @@ class RemovalHandler:
                 tags=[self.settings.general.obsolete_tag], hashes=[download_id]
             )
 
+    async def _tag_with_custom_tag(self, affected_download, download_id, handoff_tag):
+        logger.info(
+            "Job '%s' triggered handoff-tagging: %s (tag: %s)",
+            self.job_name,
+            affected_download.get("title", download_id),
+            handoff_tag,
+        )
+        qbit_client, _ = self.settings.download_clients.get_download_client_by_name(
+            affected_download["downloadClient"],
+            download_client_type="qbittorrent",
+        )
+        if qbit_client is None:
+            # this should not happen due _supports_tag_handoff guard, but keep defensive behavior
+            return
+        await qbit_client.set_tag(tags=[handoff_tag], hashes=[download_id])
+
     async def _get_handling_method(self, download_id, affected_download):
         if affected_download["protocol"] != "torrent":
             return "remove"  # handling is only implemented for torrent
@@ -69,3 +132,66 @@ class RemovalHandler:
             return self.settings.general.private_tracker_handling
 
         return self.settings.general.public_tracker_handling
+
+    def _resolve_effective_handling_method(self, action_mode, tracker_handling_method):
+        if action_mode == "remove":
+            return tracker_handling_method
+        if action_mode == "skip":
+            return "skip"
+        if action_mode == "tag_only":
+            return "tag_only"
+        return tracker_handling_method
+
+    def _get_action_mode(self):
+        action_mode = getattr(self.job, "action_mode", "remove")
+        if action_mode not in VALID_ACTION_MODES:
+            logger.error(
+                "Invalid action_mode '%s' for job '%s'. Falling back to 'remove'.",
+                action_mode,
+                self.job_name,
+            )
+            return "remove"
+        return action_mode
+
+    def _get_handoff_tag(self):
+        handoff_tag = getattr(self.job, "handoff_tag", "")
+        if handoff_tag:
+            return handoff_tag
+        return self.settings.general.obsolete_tag
+
+    def _is_deferred_arr_followup(self):
+        return bool(getattr(self.job, "deferred_arr_followup", False))
+
+    def _get_followup_trigger(self):
+        followup_trigger = getattr(self.job, "followup_trigger", "on_download_removed")
+        if followup_trigger not in VALID_FOLLOWUP_TRIGGERS:
+            logger.error(
+                "Invalid followup_trigger '%s' for job '%s'. Falling back to 'on_download_removed'.",
+                followup_trigger,
+                self.job_name,
+            )
+            return "on_download_removed"
+        return followup_trigger
+
+    def _supports_tag_handoff(self, affected_download):
+        if affected_download.get("protocol") != "torrent":
+            return False
+        if len(self.settings.download_clients.qbittorrent) == 0:
+            return False
+        qbit_client, client_type = (
+            self.settings.download_clients.get_download_client_by_name(
+                affected_download["downloadClient"],
+                download_client_type="qbittorrent",
+            )
+        )
+        return qbit_client is not None and client_type == "qbittorrent"
+
+    async def _download_exists_in_client(self, download_id, affected_download):
+        qbit_client, _ = self.settings.download_clients.get_download_client_by_name(
+            affected_download["downloadClient"],
+            download_client_type="qbittorrent",
+        )
+        if qbit_client is None:
+            return False
+        qbit_items = await qbit_client.get_qbit_items(download_id)
+        return len(qbit_items) > 0

--- a/src/settings/_jobs.py
+++ b/src/settings/_jobs.py
@@ -14,6 +14,10 @@ class JobParams:
     max_concurrent_searches: int
     min_days_between_searches: int
     target_tags: list
+    action_mode: str = "remove"
+    handoff_tag: str
+    deferred_arr_followup: bool = False
+    followup_trigger: str = "on_download_removed"
 
     def __init__(
         self,
@@ -25,6 +29,10 @@ class JobParams:
         max_concurrent_searches=None,
         min_days_between_searches=None,
         target_tags=None,
+        action_mode=None,
+        handoff_tag=None,
+        deferred_arr_followup=None,
+        followup_trigger=None,
     ):
         self.enabled = enabled
         self.keep_archives = keep_archives
@@ -34,6 +42,10 @@ class JobParams:
         self.max_concurrent_searches = max_concurrent_searches
         self.min_days_between_searches = min_days_between_searches
         self.target_tags = target_tags
+        self.action_mode = action_mode
+        self.handoff_tag = handoff_tag
+        self.deferred_arr_followup = deferred_arr_followup
+        self.followup_trigger = followup_trigger
 
         # Remove attributes that are None to keep the object clean
         self._remove_none_attributes()
@@ -55,15 +67,29 @@ class JobDefaults:
     min_speed: int = 100
     message_patterns = ["*"]
     target_tags = []
+    action_mode: str = "remove"
+    handoff_tag: str = ""
+    deferred_arr_followup: bool = False
+    followup_trigger: str = "on_download_removed"
 
     def __init__(self, config, settings):
         job_defaults_config = config.get("job_defaults", {})
         self.target_tags.append(settings.general.obsolete_tag)
         self.max_strikes = job_defaults_config.get("max_strikes", self.max_strikes)
-        self.max_concurrent_searches = job_defaults_config.get("max_concurrent_searches", self.max_concurrent_searches)
+        self.max_concurrent_searches = job_defaults_config.get(
+            "max_concurrent_searches", self.max_concurrent_searches
+        )
         self.min_days_between_searches = job_defaults_config.get(
             "min_days_between_searches",
             self.min_days_between_searches,
+        )
+        self.action_mode = job_defaults_config.get("action_mode", self.action_mode)
+        self.handoff_tag = job_defaults_config.get("handoff_tag", self.handoff_tag)
+        self.deferred_arr_followup = job_defaults_config.get(
+            "deferred_arr_followup", self.deferred_arr_followup
+        )
+        self.followup_trigger = job_defaults_config.get(
+            "followup_trigger", self.followup_trigger
         )
         validate_data_types(self)
 
@@ -78,23 +104,38 @@ class Jobs:
         del self.job_defaults
 
     def _set_job_defaults(self):
-        self.remove_bad_files = JobParams(keep_archives=self.job_defaults.keep_archives)
+        removal_defaults = {
+            "action_mode": self.job_defaults.action_mode,
+            "handoff_tag": self.job_defaults.handoff_tag,
+            "deferred_arr_followup": self.job_defaults.deferred_arr_followup,
+            "followup_trigger": self.job_defaults.followup_trigger,
+        }
+        self.remove_bad_files = JobParams(
+            keep_archives=self.job_defaults.keep_archives,
+            **removal_defaults,
+        )
         self.remove_done_seeding = JobParams(target_tags=self.job_defaults.target_tags)
-        self.remove_failed_downloads = JobParams()
+        self.remove_failed_downloads = JobParams(**removal_defaults)
         self.remove_failed_imports = JobParams(
             message_patterns=self.job_defaults.message_patterns,
+            **removal_defaults,
         )
         self.remove_metadata_missing = JobParams(
             max_strikes=self.job_defaults.max_strikes,
+            **removal_defaults,
         )
-        self.remove_missing_files = JobParams()
-        self.remove_orphans = JobParams()
+        self.remove_missing_files = JobParams(**removal_defaults)
+        self.remove_orphans = JobParams(**removal_defaults)
         self.remove_slow = JobParams(
             max_strikes=self.job_defaults.max_strikes,
             min_speed=self.job_defaults.min_speed,
+            **removal_defaults,
         )
-        self.remove_stalled = JobParams(max_strikes=self.job_defaults.max_strikes)
-        self.remove_unmonitored = JobParams()
+        self.remove_stalled = JobParams(
+            max_strikes=self.job_defaults.max_strikes,
+            **removal_defaults,
+        )
+        self.remove_unmonitored = JobParams(**removal_defaults)
         self.search_unmet_cutoff = JobParams(
             max_concurrent_searches=self.job_defaults.max_concurrent_searches,
             min_days_between_searches=self.job_defaults.min_days_between_searches,

--- a/src/settings/_user_config.py
+++ b/src/settings/_user_config.py
@@ -25,6 +25,10 @@ CONFIG_MAPPING = {
         "MAX_STRIKES",
         "MIN_DAYS_BETWEEN_SEARCHES",
         "MAX_CONCURRENT_SEARCHES",
+        "ACTION_MODE",
+        "HANDOFF_TAG",
+        "DEFERRED_ARR_FOLLOWUP",
+        "FOLLOWUP_TRIGGER",
     ],
     "jobs": [
         "REMOVE_BAD_FILES",

--- a/tests/jobs/test_removal_handler.py
+++ b/tests/jobs/test_removal_handler.py
@@ -52,3 +52,85 @@ async def test_get_handling_method(
         "A", affected_download
     )
     assert result == expected
+
+
+def _make_tag_only_handler(*, deferred_arr_followup=True):
+    arr = MagicMock()
+    arr.tracker.private = []
+    arr.tracker.deleted = []
+    arr.remove_queue_item = AsyncMock(return_value=True)
+
+    qbit_client = MagicMock()
+    qbit_client.set_tag = AsyncMock()
+    qbit_client.get_qbit_items = AsyncMock(return_value=[{"hash": "A"}])
+
+    settings = MagicMock()
+    settings.download_clients.qbittorrent = [qbit_client]
+    settings.download_clients.get_download_client_by_name.return_value = (
+        qbit_client,
+        "qbittorrent",
+    )
+    settings.general.private_tracker_handling = "remove"
+    settings.general.public_tracker_handling = "remove"
+    settings.general.obsolete_tag = "Obsolete"
+
+    settings.jobs.remove_orphans.action_mode = "tag_only"
+    settings.jobs.remove_orphans.handoff_tag = "cleanup-ready"
+    settings.jobs.remove_orphans.deferred_arr_followup = deferred_arr_followup
+    settings.jobs.remove_orphans.followup_trigger = "on_download_removed"
+
+    handler = RemovalHandler(arr=arr, settings=settings, job_name="remove_orphans")
+
+    affected_downloads = {
+        "A": {
+            "downloadClient": "qBittorrent",
+            "protocol": "torrent",
+            "title": "Torrent A",
+            "queue_ids": [11],
+        }
+    }
+    return handler, arr, qbit_client, affected_downloads
+
+
+@pytest.mark.asyncio
+async def test_tag_only_handoff_waits_for_external_removal():
+    handler, arr, qbit_client, affected_downloads = _make_tag_only_handler(
+        deferred_arr_followup=True
+    )
+    qbit_client.get_qbit_items.return_value = [{"hash": "a"}]
+
+    await handler.remove_downloads(affected_downloads, blocklist=True)
+
+    qbit_client.set_tag.assert_awaited_once_with(tags=["cleanup-ready"], hashes=["A"])
+    arr.remove_queue_item.assert_not_awaited()
+    assert "A" in arr.tracker.deleted
+
+
+@pytest.mark.asyncio
+async def test_tag_only_handoff_triggers_followup_after_external_removal():
+    handler, arr, qbit_client, affected_downloads = _make_tag_only_handler(
+        deferred_arr_followup=True
+    )
+    qbit_client.get_qbit_items.return_value = []
+
+    await handler.remove_downloads(affected_downloads, blocklist=False)
+
+    qbit_client.set_tag.assert_awaited_once_with(tags=["cleanup-ready"], hashes=["A"])
+    arr.remove_queue_item.assert_awaited_once_with(queue_id=11, blocklist=False)
+    assert "A" in arr.tracker.deleted
+
+
+@pytest.mark.asyncio
+async def test_tag_only_handoff_skips_if_download_cannot_be_tagged():
+    handler, arr, qbit_client, affected_downloads = _make_tag_only_handler(
+        deferred_arr_followup=True
+    )
+    qbit_client.set_tag.reset_mock()
+    settings = handler.settings
+    settings.download_clients.get_download_client_by_name.return_value = (None, None)
+
+    await handler.remove_downloads(affected_downloads, blocklist=False)
+
+    qbit_client.set_tag.assert_not_awaited()
+    arr.remove_queue_item.assert_not_awaited()
+    assert "A" not in arr.tracker.deleted

--- a/tests/settings/test_jobs.py
+++ b/tests/settings/test_jobs.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock
+
+from src.settings._jobs import Jobs
+
+
+def _make_settings(obsolete_tag="Obsolete"):
+    settings = MagicMock()
+    settings.general.obsolete_tag = obsolete_tag
+    return settings
+
+
+def test_job_defaults_apply_to_arr_removal_jobs():
+    config = {
+        "job_defaults": {
+            "action_mode": "tag_only",
+            "handoff_tag": "cleanup-ready",
+            "deferred_arr_followup": True,
+            "followup_trigger": "on_download_removed",
+        },
+        "jobs": {
+            "remove_orphans": {},
+            "remove_stalled": {},
+        },
+    }
+
+    jobs = Jobs(config, _make_settings())
+
+    assert jobs.remove_orphans.action_mode == "tag_only"
+    assert jobs.remove_orphans.handoff_tag == "cleanup-ready"
+    assert jobs.remove_orphans.deferred_arr_followup is True
+    assert jobs.remove_orphans.followup_trigger == "on_download_removed"
+
+    assert jobs.remove_stalled.action_mode == "tag_only"
+    assert jobs.remove_stalled.handoff_tag == "cleanup-ready"
+    assert jobs.remove_stalled.deferred_arr_followup is True
+
+
+def test_job_level_overrides_job_defaults_for_handoff_fields():
+    config = {
+        "job_defaults": {
+            "action_mode": "remove",
+            "handoff_tag": "Obsolete",
+            "deferred_arr_followup": False,
+            "followup_trigger": "on_download_removed",
+        },
+        "jobs": {
+            "remove_orphans": {
+                "action_mode": "tag_only",
+                "handoff_tag": "cleanup-ready",
+                "deferred_arr_followup": True,
+                "followup_trigger": "on_download_removed",
+            },
+        },
+    }
+
+    jobs = Jobs(config, _make_settings())
+
+    assert jobs.remove_orphans.action_mode == "tag_only"
+    assert jobs.remove_orphans.handoff_tag == "cleanup-ready"
+    assert jobs.remove_orphans.deferred_arr_followup is True
+    assert jobs.remove_orphans.followup_trigger == "on_download_removed"

--- a/tests/settings/test_user_config_from_env.py
+++ b/tests/settings/test_user_config_from_env.py
@@ -15,6 +15,10 @@ from src.settings._user_config import _load_from_env
 LOG_LEVEL_VALUE = "VERBOSE"
 TIMER_VALUE = "10"
 SSL_VERIFICATION_VALUE = "true"
+ACTION_MODE_VALUE = "tag_only"
+HANDOFF_TAG_VALUE = "cleanup-ready"
+DEFERRED_ARR_FOLLOWUP_VALUE = "true"
+FOLLOWUP_TRIGGER_VALUE = "on_download_removed"
 
 # List
 ignored_download_clients_yaml = textwrap.dedent(
@@ -80,6 +84,10 @@ def fixture_env_vars():
         "LOG_LEVEL": LOG_LEVEL_VALUE,
         "TIMER": TIMER_VALUE,
         "SSL_VERIFICATION": SSL_VERIFICATION_VALUE,
+        "ACTION_MODE": ACTION_MODE_VALUE,
+        "HANDOFF_TAG": HANDOFF_TAG_VALUE,
+        "DEFERRED_ARR_FOLLOWUP": DEFERRED_ARR_FOLLOWUP_VALUE,
+        "FOLLOWUP_TRIGGER": FOLLOWUP_TRIGGER_VALUE,
         "IGNORED_DOWNLOAD_CLIENTS": ignored_download_clients_yaml,
         "REMOVE_BAD_FILES": remove_bad_files_yaml,
         "REMOVE_SLOW": remove_slow_yaml,
@@ -113,6 +121,10 @@ qbit_expected = yaml.safe_load(qbit_yaml)
             "ignored_download_clients",
             remove_ignored_download_clients_expected,
         ),
+        ("job_defaults", "action_mode", ACTION_MODE_VALUE),
+        ("job_defaults", "handoff_tag", HANDOFF_TAG_VALUE),
+        ("job_defaults", "deferred_arr_followup", True),
+        ("job_defaults", "followup_trigger", FOLLOWUP_TRIGGER_VALUE),
         ("jobs", "remove_bad_files", remove_bad_files_expected),
         ("jobs", "remove_slow", remove_slow_expected),
         ("jobs", "remove_stalled", remove_stalled_expected),


### PR DESCRIPTION
## Summary
Implements a configurable tag-only handoff workflow so Decluttarr can defer cleanup ownership to an external service (for example qbit_manage), while optionally triggering ARR follow-up only after external removal is detected.

## What Changed
- Added new ARR-removal job controls:
  - `action_mode: remove | skip | tag_only`
  - `handoff_tag`
  - `deferred_arr_followup`
  - `followup_trigger` (currently `on_download_removed`)
- Extended `JobDefaults` and job-level parsing for the above fields.
- Added env parsing support for job-default keys (`ACTION_MODE`, `HANDOFF_TAG`, `DEFERRED_ARR_FOLLOWUP`, `FOLLOWUP_TRIGGER`).
- Implemented `tag_only` path in `RemovalHandler`:
  - Apply handoff tag to matching torrent.
  - If `deferred_arr_followup: true`, detect whether the download hash is gone from qBittorrent.
  - Trigger ARR queue removal/blocklist follow-up once external removal is detected.
- Added config/docs updates in `config/config_example.yaml` and `README.md`.

## Tests
- Added new tests for:
  - tag-only handoff waiting behavior
  - deferred follow-up trigger after external removal
  - safe skip when tag handoff is unsupported
  - job defaults + job-level override parsing for new fields
  - env-loading for new job-default keys
- Full suite run locally:
  - `python3 -m pytest -q`

## Related
- Closes #335
