### PR TITLE
[NEEDS CODE REVIEWER] Handle failed /sync/maindata requests in check_connected

### DIFF
--- a/src/settings/_download_clients_qbit.py
+++ b/src/settings/_download_clients_qbit.py
@@ -260,17 +260,24 @@ class QbitClient:
         logger.debug(
             "_download_clients_qBit.py/check_qbit_reachability: Checking if qbit is connected to the internet",
         )
-        qbit_connection_status = (
-            (
-                await make_request(
-                    "get",
-                    self.api_url + "/sync/maindata",
-                    self.settings,
-                    timeout=self.timeout,
-                    cookies=self.cookie,
-                )
-            ).json()
-        )["server_state"]["connection_status"]
+        try:
+            qbit_connection_status = (
+                (
+                    await make_request(
+                        "get",
+                        self.api_url + "/sync/maindata",
+                        self.settings,
+                        timeout=self.timeout,
+                        cookies=self.cookie,
+                    )
+                ).json()
+            )["server_state"]["connection_status"]
+        except Exception:
+            logger.warning(
+                ">>> %s: Failed to reach /sync/maindata. Treating as disconnected.",
+                self.name,
+            )
+            return False
         if qbit_connection_status == "disconnected":
             return False
         return True


### PR DESCRIPTION
Previously, an HTTP error from the qBit API (e.g. a 500 from rdt-client) would crash decluttarr entirely. Now the error is caught and treated as a disconnected client, so the cycle is skipped and retried next run.

Here's an example of what happens:

```
decluttarr   | ERROR   | HTTP error occurred: 500 Server Error: Internal Server Error for url: http://somerdtclient:6500/api/v2/sync/maindata
decluttarr   | Traceback (most recent call last):
decluttarr   |   File "/app/src/utils/common.py", line 79, in make_request
decluttarr   |     response.raise_for_status()
decluttarr   |   File "/usr/local/lib/python3.10/site-packages/requests/models.py", line 1026, in raise_for_status
decluttarr   |     raise HTTPError(http_error_msg, response=self)
decluttarr   | requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: http://somerdtclient:6500/api/v2/sync/maindata
decluttarr   | Traceback (most recent call last):
decluttarr   |   File "/app/main.py", line 79, in <module>
decluttarr   |     asyncio.run(main())
decluttarr   |   File "/usr/local/lib/python3.10/asyncio/runners.py", line 44, in run
decluttarr   |     return loop.run_until_complete(main)
decluttarr   |   File "/usr/local/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
decluttarr   |     return future.result()
decluttarr   |   File "/app/main.py", line 67, in main
decluttarr   |     await job_manager.run_jobs(arr)
decluttarr   |   File "/app/src/job_manager.py", line 27, in run_jobs
decluttarr   |     await self.removal_jobs()
decluttarr   |   File "/app/src/job_manager.py", line 73, in removal_jobs
decluttarr   |     if not await self._download_clients_connected():
decluttarr   |   File "/app/src/job_manager.py", line 130, in _download_clients_connected
decluttarr   |     if not await self._check_client_connection_status(clients):
decluttarr   |   File "/app/src/job_manager.py", line 139, in _check_client_connection_status
decluttarr   |     if not await client.check_connected():
decluttarr   |   File "/app/src/settings/_download_clients_qbit.py", line 233, in check_connected
decluttarr   |     await make_request(
decluttarr   |   File "/app/src/utils/common.py", line 79, in make_request
decluttarr   |     response.raise_for_status()
decluttarr   |   File "/usr/local/lib/python3.10/site-packages/requests/models.py", line 1026, in raise_for_status
decluttarr   |     raise HTTPError(http_error_msg, response=self)
decluttarr   | requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: http://somerdtclient:6500/api/v2/sync/maindata
decluttarr exited with code 1
```

This closes #348 