### PR TITLE
Fix dynamic cookie name introduced in qBit 5.2.x

### DIFF
--- a/src/settings/_download_clients_qbit.py
+++ b/src/settings/_download_clients_qbit.py
@@ -1,4 +1,5 @@
 from packaging import version
+from requests.cookies import RequestsCookieJar
 
 from src.settings._constants import ApiEndpoints, MinVersions
 from src.utils.common import extract_json_from_response, make_request, wait_and_exit
@@ -102,11 +103,27 @@ class QbitClient:
             if response.text == "Fails.":
                 _connection_error()
 
-            self.cookie = {"SID": response.cookies["SID"]}
+            self.cookie = self.extract_sid(response.cookies)
         except Exception as e:
             logger.error(f"Error refreshing qBit cookie: {e}")
             self.cookie = {}
             raise QbitError(e) from e
+
+    @staticmethod
+    def extract_sid(cookie_jar: RequestsCookieJar) -> dict[str, str]:
+        """
+        Extract the SID or dynamic QBIT_SID_<WEB_UI_PORT>.
+
+        This supports the legacy 'SID' key and the dynamic port-based
+        naming introduced in qBit 5.2_x.
+        """
+        for cookie in cookie_jar:
+            # Simple, fast, and covers both legacy and new dynamic ports
+            if cookie.name == "SID" or cookie.name.startswith("QBIT_SID_"):
+                return {cookie.name: cookie.value}
+
+        error = "No qBit cookie found"
+        raise QbitError(error)
 
     async def fetch_version(self):
         """Fetch the current qBittorrent version."""
@@ -292,7 +309,9 @@ class QbitClient:
                     logger.debug(
                         "_download_clients_qBit/get_protected_and_private: Checking if torrents are private (only done for old qbit versions)",
                     )
-                    qbit_item_props = await self.get_torrent_properties(qbit_item["hash"])
+                    qbit_item_props = await self.get_torrent_properties(
+                        qbit_item["hash"]
+                    )
 
                     if not qbit_item_props:
                         logger.error(
@@ -376,14 +395,13 @@ class QbitClient:
     async def get_torrent_properties(self, qbit_hash):
         params = {"hash": qbit_hash.lower()}
         response = await make_request(
-                        "get",
-                        self.api_url + "/torrents/properties",
-                        self.settings,
-                        params=params,
-                        cookies=self.cookie,
-                    )
+            "get",
+            self.api_url + "/torrents/properties",
+            self.settings,
+            params=params,
+            cookies=self.cookie,
+        )
         return response.json()
-
 
     async def get_torrent_files(self, download_id):
         # this may not work if the wrong qbit

--- a/src/settings/_download_clients_qbit.py
+++ b/src/settings/_download_clients_qbit.py
@@ -115,7 +115,7 @@ class QbitClient:
         Extract the SID or dynamic QBIT_SID_<WEB_UI_PORT>.
 
         This supports the legacy 'SID' key and the dynamic port-based
-        naming introduced in qBit 5.2_x.
+        naming introduced in qBit 5.2.x.
         """
         for cookie in cookie_jar:
             # Simple, fast, and covers both legacy and new dynamic ports

--- a/src/settings/_download_clients_qbit.py
+++ b/src/settings/_download_clients_qbit.py
@@ -395,13 +395,14 @@ class QbitClient:
     async def get_torrent_properties(self, qbit_hash):
         params = {"hash": qbit_hash.lower()}
         response = await make_request(
-            "get",
-            self.api_url + "/torrents/properties",
-            self.settings,
-            params=params,
-            cookies=self.cookie,
-        )
+                        "get",
+                        self.api_url + "/torrents/properties",
+                        self.settings,
+                        params=params,
+                        cookies=self.cookie,
+                    )
         return response.json()
+
 
     async def get_torrent_files(self, download_id):
         # this may not work if the wrong qbit

--- a/tests/settings/test_download_clients_qbit.py
+++ b/tests/settings/test_download_clients_qbit.py
@@ -1,0 +1,51 @@
+import pytest
+
+from requests.cookies import RequestsCookieJar
+from src.settings._download_clients_qbit import QbitClient, QbitError
+
+
+@pytest.mark.parametrize(
+    "cookie_name, cookie_value, expected",
+    [
+        # Legacy format
+        ("SID", "abc", {"SID": "abc"}),
+        # New dynamic port format (qBit 5.2+)
+        ("QBIT_SID_8080", "xyz", {"QBIT_SID_8080": "xyz"}),
+        ("QBIT_SID_12345", "token123", {"QBIT_SID_12345": "token123"}),
+    ],
+)
+def test_extract_sid_success(cookie_name, cookie_value, expected):
+    """Test successful extraction for various valid cookie names."""
+    jar = RequestsCookieJar()
+    jar.set(cookie_name, cookie_value)
+
+    assert QbitClient.extract_sid(jar) == expected
+
+
+@pytest.mark.parametrize(
+    "cookies",
+    [
+        {},  # Empty jar
+        {"WRONG_NAME": "value"},  # Incorrect name
+        {"sid": "lowercase_fails"},  # Case sensitivity check
+    ],
+)
+def test_extract_sid_failures(cookies):
+    """Test that invalid cookies properly raise QbitError."""
+    jar = RequestsCookieJar()
+    for name, val in cookies.items():
+        jar.set(name, val)
+
+    with pytest.raises(QbitError, match="No qBit cookie found"):
+        QbitClient.extract_sid(jar)
+
+
+def test_extract_sid_priority():
+    """Verify it returns the first valid match it encounters."""
+    jar = RequestsCookieJar()
+    jar.set("SID", "first")
+    jar.set("QBIT_SID_9090", "second")
+
+    result = QbitClient.extract_sid(jar)
+    # Since it's a loop over the jar, it returns the first match found
+    assert list(result.values())[0] in ["first", "second"]

--- a/tests/settings/test_download_clients_qbit.py
+++ b/tests/settings/test_download_clients_qbit.py
@@ -38,14 +38,3 @@ def test_extract_sid_failures(cookies):
 
     with pytest.raises(QbitError, match="No qBit cookie found"):
         QbitClient.extract_sid(jar)
-
-
-def test_extract_sid_priority():
-    """Verify it returns the first valid match it encounters."""
-    jar = RequestsCookieJar()
-    jar.set("SID", "first")
-    jar.set("QBIT_SID_9090", "second")
-
-    result = QbitClient.extract_sid(jar)
-    # Since it's a loop over the jar, it returns the first match found
-    assert list(result.values())[0] in ["first", "second"]


### PR DESCRIPTION
qBitorrent introduces new cookie name in version 5.2.x.
Previously, they called it "SID", new it is "QBIT_SID_<WebUI Port>".

Reference: https://github.com/qbittorrent/qBittorrent/issues/24190


This fix handles both versions.
Fixes #351 
