### PR TITLE
chore: Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,6 +36,21 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: os
+    attributes:
+      label: Host OS / architecture
+      description: |
+        Where decluttarr is running. Path-related bugs (especially `detect_deletions`) and qBit cookie issues sometimes behave differently on Windows or ARM.
+      options:
+        - Linux x86_64 (amd64)
+        - Linux ARM (arm64 / armv7)
+        - macOS
+        - Windows
+        - Other (describe under "Steps to reproduce")
+    validations:
+      required: true
+
   - type: input
     id: arr_versions
     attributes:
@@ -51,6 +66,32 @@ body:
       label: Download client + version
       description: qBittorrent / SABnzbd / etc. and version. Write `n/a` if the bug doesn't involve a download client.
       placeholder: "e.g. qBittorrent 5.2.0, or n/a"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: test_run
+    attributes:
+      label: test_run state
+      description: |
+        Removal-related bugs behave very differently with `test_run: true` (no actual removals) vs `false`. Pick the value of `general.test_run` (or `TEST_RUN`) when the bug occurred.
+      options:
+        - "false (production — actual removals)"
+        - "true (test_run mode — no actual removals)"
+        - Reproduces with both
+        - N/A (bug doesn't involve removal logic)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: Reproduction frequency
+      options:
+        - Always (every cycle / every time)
+        - Sometimes (intermittent)
+        - Once / haven't tried again
+        - Unknown
     validations:
       required: true
 
@@ -75,6 +116,8 @@ body:
       label: Debug-level logs
       description: |
         Set `log_level: DEBUG` in your config, reproduce the issue, and paste the relevant log section here. Please include enough context (lines before and after the error) to show what was running.
+
+        **Sanitize before pasting:** scrub any `?apikey=...` query parameters, `Authorization:` headers, session cookies, and arr/qBit URLs you'd rather not share. Decluttarr already redacts most `X-Api-Key` headers but not query-string keys.
       render: shell
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
     attributes:
       label: Decluttarr version
       description: |
-        The Docker image tag you pulled (typically `latest` or `dev`), or for local Python users the short commit hash from `git rev-parse --short HEAD`.
+        The Docker image tag you pulled (typically `latest` or `dev`) or — for local Python users — the short commit hash from `git rev-parse --short HEAD`. Also visible in the `🛠️  Decluttarr - Settings 🛠️` startup banner under `image_tag` / `short_commit_id` (which you'll be pasting in the logs field below).
       placeholder: "e.g. latest, dev, or 51b6a4c"
     validations:
       required: true
@@ -96,28 +96,19 @@ body:
       required: true
 
   - type: textarea
-    id: config
-    attributes:
-      label: Sanitized config
-      description: |
-        Your `config.yaml` (or env-var equivalents) with **API keys, passwords, and other secrets removed or redacted**. The form will render this as a code block automatically.
-      render: yaml
-      placeholder: |
-        general:
-          log_level: DEBUG
-          test_run: true
-        # ...
-    validations:
-      required: true
-
-  - type: textarea
     id: logs
     attributes:
-      label: Debug-level logs
+      label: Decluttarr startup banner + debug logs
       description: |
-        Set `log_level: DEBUG` in your config, reproduce the issue, and paste the relevant log section here. Please include enough context (lines before and after the error) to show what was running.
+        Please follow these three steps to produce a useful log dump:
 
-        **Sanitize before pasting:** scrub any `?apikey=...` query parameters, `Authorization:` headers, session cookies, and arr/qBit URLs you'd rather not share. Decluttarr already redacts most `X-Api-Key` headers but not query-string keys.
+        1. **Disable jobs not related to your issue** in your config — keeps the logs focused and short
+        2. **Set `log_level: DEBUG`** (or `VERBOSE` if DEBUG is too noisy)
+        3. **Restart decluttarr and paste everything from the `🛠️  Decluttarr - Settings 🛠️` startup banner through the cycle that exhibits the bug**
+
+        The startup banner already contains `image_tag` / `short_commit_id` and the entire active config (general, jobs, instances, download clients) with API keys masked as `*****`.
+
+        **Still sanitize before pasting:** scrub any `?apikey=...` query parameters, `Authorization:` headers, session cookies, and any arr/qBit URLs you'd rather not share. Decluttarr already redacts `X-Api-Key` headers but not query-string keys.
       render: shell
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,111 @@
+name: 🐛 Bug Report
+description: Report a reproducible problem with decluttarr
+title: "[Bug] "
+labels: ["Bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. **Please fill in every required field** — incomplete reports take much longer to resolve and may be closed pending more info.
+
+        Before submitting, please confirm:
+        - You've read the [README](https://github.com/ManiMatter/decluttarr#dependencies--hints--faq), especially the **Dependencies & Hints & FAQ** section
+        - You've searched [open and closed issues](https://github.com/ManiMatter/decluttarr/issues?q=is%3Aissue) for the same problem
+        - This is a reproducible bug, not a configuration question (use [Discussions](https://github.com/ManiMatter/decluttarr/discussions) for those)
+
+  - type: input
+    id: version
+    attributes:
+      label: Decluttarr version
+      description: |
+        Image tag (e.g. `latest`, `dev`) or commit hash. Find it in the startup log line `Decluttarr <version>`.
+      placeholder: "e.g. latest, dev, or 51b6a4c"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment method
+      options:
+        - Docker Compose with config.yaml
+        - Docker Compose with environment variables
+        - docker run
+        - Local Python (main.py)
+        - Other (describe under "Steps to reproduce")
+    validations:
+      required: true
+
+  - type: input
+    id: arr_versions
+    attributes:
+      label: "*arr instance versions"
+      description: Versions of any Sonarr / Radarr / Lidarr / Readarr / Whisparr instances involved in the bug.
+      placeholder: "e.g. Sonarr 4.0.10, Radarr 5.18.4"
+    validations:
+      required: true
+
+  - type: input
+    id: download_client_version
+    attributes:
+      label: Download client + version
+      description: qBittorrent / SABnzbd / etc. and version. Write `n/a` if the bug doesn't involve a download client.
+      placeholder: "e.g. qBittorrent 5.2.0, or n/a"
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Sanitized config
+      description: |
+        Your `config.yaml` (or env-var equivalents) with **API keys, passwords, and other secrets removed or redacted**. The form will render this as a code block automatically.
+      render: yaml
+      placeholder: |
+        general:
+          log_level: DEBUG
+          test_run: true
+        # ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Debug-level logs
+      description: |
+        Set `log_level: DEBUG` in your config, reproduce the issue, and paste the relevant log section here. Please include enough context (lines before and after the error) to show what was running.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Start decluttarr with the config above
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Screenshots, related issues, what you've already tried, hardware/OS details if relevant, etc.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
     attributes:
       label: Decluttarr version
       description: |
-        Image tag (e.g. `latest`, `dev`) or commit hash. Find it in the startup log line `Decluttarr <version>`.
+        The Docker image tag you pulled (typically `latest` or `dev`), or for local Python users the short commit hash from `git rev-parse --short HEAD`.
       placeholder: "e.g. latest, dev, or 51b6a4c"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,10 +16,13 @@ body:
   - type: input
     id: version
     attributes:
-      label: Decluttarr version
+      label: Decluttarr commit hash
       description: |
-        The Docker image tag you pulled (typically `latest` or `dev`) or — for local Python users — the short commit hash from `git rev-parse --short HEAD`. Also visible in the `🛠️  Decluttarr - Settings 🛠️` startup banner under `image_tag` / `short_commit_id` (which you'll be pasting in the logs field below).
-      placeholder: "e.g. latest, dev, or 51b6a4c"
+        The **short commit hash** of the build you're running. `latest` / `dev` tags move too quickly to be useful for reproduction, so please give us the specific commit.
+
+        - **Docker users:** grab it from the `short_commit_id` line in the `🛠️  Decluttarr - Settings 🛠️` startup banner (you'll be pasting the full banner in the logs field below)
+        - **Local Python users:** run `git rev-parse --short HEAD`
+      placeholder: "e.g. 51b6a4c"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions, usage help, config troubleshooting
+    url: https://github.com/ManiMatter/decluttarr/discussions
+    about: |
+      For general questions, configuration help, or "why is this happening" — please use Discussions instead of opening an issue. The issue tracker is reserved for reproducible bugs and feature requests.
+  - name: 📚 README & FAQ
+    url: https://github.com/ManiMatter/decluttarr#dependencies--hints--faq
+    about: |
+      Many common problems (qBit cookie issues, multi-instance YAML format, "no valid arr instances" errors, etc.) are covered in the README's Dependencies & Hints & FAQ section. Please check there first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: ✨ Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature] "
+labels: ["Feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an improvement! Please make sure there isn't already an [open issue](https://github.com/ManiMatter/decluttarr/issues?q=is%3Aissue+is%3Aopen+label%3AFeature) or [discussion](https://github.com/ManiMatter/decluttarr/discussions) covering the same idea.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point that the feature would address. What are you trying to accomplish that's currently awkward, manual, or impossible?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: |
+        How would this feature work from the user's perspective?
+        - What does the config look like?
+        - What does decluttarr do at runtime?
+        - Are there new env vars / yaml keys / log messages?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, other tools that solve this differently, or alternative implementations you've thought through.
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Mockups, references, related issues, or willingness to contribute a PR.


### PR DESCRIPTION
## Summary

Adds GitHub issue templates under `.github/ISSUE_TEMPLATE/` to address the *"Set up Issue templates"* item in discussion #345.

Two structured templates (Bug, Feature) plus a chooser config that disables blank issues and redirects general questions to Discussions.

## What's in here

- **`bug_report.yml`** — required fields for: decluttarr version, deployment method, host OS / architecture, *arr versions, download client + version, `test_run` state, reproduction frequency, sanitized config, debug logs (with API-key sanitization reminder), steps to reproduce, expected vs actual behavior. Auto-applies the `Bug` label.
- **`feature_request.yml`** — required: problem statement, proposed solution. Optional: alternatives, extras. Auto-applies the `Feature` label.
- **`config.yml`** — `blank_issues_enabled: false` plus contact links to GitHub Discussions and the README's *Dependencies & Hints & FAQ* section.

## Why these fields

Surveyed the last 25 closed issues and noticed the same pattern repeatedly: 7–13 comment threads spent extracting version, deployment method, debug logs, and config from terse OPs. The required fields here are exactly the info that was being asked for in those comment threads.

The `Unclear` label exists because maintainers can't always tell whether a report is a bug, a config question, or unclear behavior — that's what `config.yml`'s blank-issue lockout + Discussions redirect is meant to fix.

## Test plan

- [x] After merge, visit `/issues/new/choose` and confirm the chooser shows two templates + two contact links
- [ ] Submit a test bug report through the form and confirm the required fields gate submit
- [ ] Confirm the `Bug` and `Feature` labels are auto-applied

Closes part of the chore list in #345.