### PR TITLE
Fix qbit 5.2 token name (2)

### DIFF
--- a/src/settings/_download_clients_qbit.py
+++ b/src/settings/_download_clients_qbit.py
@@ -112,14 +112,14 @@ class QbitClient:
     @staticmethod
     def extract_sid(cookie_jar: RequestsCookieJar) -> dict[str, str]:
         """
-        Extract the SID or dynamic QBIT_SID_<WEB_UI_PORT>.
+        Extract the SID or dynamic QBT_SID_<WEB_UI_PORT>.
 
         This supports the legacy 'SID' key and the dynamic port-based
         naming introduced in qBit 5.2.x.
         """
         for cookie in cookie_jar:
             # Simple, fast, and covers both legacy and new dynamic ports
-            if cookie.name == "SID" or cookie.name.startswith("QBIT_SID_"):
+            if cookie.name == "SID" or cookie.name.startswith("QBT_SID_"):
                 return {cookie.name: cookie.value}
 
         error = "No qBit cookie found"

--- a/tests/settings/test_download_clients_qbit.py
+++ b/tests/settings/test_download_clients_qbit.py
@@ -10,8 +10,8 @@ from src.settings._download_clients_qbit import QbitClient, QbitError
         # Legacy format
         ("SID", "abc", {"SID": "abc"}),
         # New dynamic port format (qBit 5.2+)
-        ("QBIT_SID_8080", "xyz", {"QBIT_SID_8080": "xyz"}),
-        ("QBIT_SID_12345", "token123", {"QBIT_SID_12345": "token123"}),
+        ("QBT_SID_8080", "xyz", {"QBT_SID_8080": "xyz"}),
+        ("QBT_SID_12345", "token123", {"QBT_SID_12345": "token123"}),
     ],
 )
 def test_extract_sid_success(cookie_name, cookie_value, expected):


### PR DESCRIPTION
This is an update on the PR https://github.com/ManiMatter/decluttarr/pull/352. The cookie name is `QBT_SID_` not `QBIT_SID_`

https://github.com/qbittorrent/qBittorrent/pull/23228/changes#diff-3e6066bb29aad27c4d6a1e2476f0c3b8941a4506033b28ca2550a88da96954e6R72 