### PR TITLE
[NEEDS CODE REVIEWER]  fix: Handle failed status requests in SABnzbd check_connected

### DIFF
--- a/src/settings/_download_clients_sabnzbd.py
+++ b/src/settings/_download_clients_sabnzbd.py
@@ -125,13 +125,20 @@ class SabnzbdClient:
             "_download_clients_sabnzbd.py/check_connected: Checking if SABnzbd is connected"
         )
         params = {"mode": "status", "apikey": self.api_key, "output": "json"}
-        response = await make_request(
-            "get",
-            self.api_url,
-            self.settings,
-            params=params,
-        )
-        status_data = response.json()
+        try:
+            response = await make_request(
+                "get",
+                self.api_url,
+                self.settings,
+                params=params,
+            )
+            status_data = response.json()
+        except Exception:
+            logger.warning(
+                ">>> %s: Failed to reach SABnzbd status endpoint. Treating as disconnected.",
+                self.name,
+            )
+            return False
         # SABnzbd doesn't have a direct "disconnected" status like qBittorrent
         # We check if we can get status successfully
         return "status" in status_data


### PR DESCRIPTION
## Summary

Mirrors the qBit fix from #342 (just approved) for the same bug class in SABnzbd.

Previously, an HTTP error from SABnzbd's status endpoint (e.g. a 500) would raise out of `make_request` and crash decluttarr entirely. Now the error is caught and treated as a disconnected client, so the cycle is skipped and retried next run.

**Before:** SAB returns 500 → `HTTPError` propagates up through `check_connected` → `_check_client_connection_status` → `_download_clients_connected` → `removal_jobs` → `run_jobs` → `main` → process exits, container restart-loops.

**After:** SAB returns 500 → caught locally → warning logged → `False` returned → that client is skipped this cycle, other clients/instances continue, next cycle retries.

Same shape as #342 — granular per-client handling, not a broad top-level catch.

## Test plan

Smoke tested four paths against the patched `check_connected`:

- [x] HTTPError (500) → returns `False`, warning logged, no crash
- [x] Connected (`{"status": True}`) → returns `True`
- [x] Missing `status` key → returns `False`
- [x] Invalid JSON (`response.json()` raises) → returns `False`

Full test suite: 198/198 passing.

## Notes

- No new tests added — there's no existing coverage for `check_connected` in either qbit or sabnzbd, so this stays consistent with the codebase. Happy to add tests for both if preferred.
- Targets `dev` for consistency with #342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)