### PR TITLE
[NEEDS CODE REVIEWER] feat(remove_metadata_missing): detect stuck metadata for non-qBittorrent clients (opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,11 +551,13 @@ This is the interesting section. It defines which job you want decluttarr to run
 -   Steers whether downloads stuck obtaining metadata are removed from the queue
 -   Blocklisted: Yes
 -   Type: Boolean or Dict
--   Permissible Values: True, False or max_strikes (int)
+-   Permissible Values: True, False or max_strikes (int), detect_via_missing_size (bool)
 -   Is Mandatory: No (Defaults to False)
 -   Note:
       - With max_strikes you can define how many times this torrent can be caught before being removed
       - Instead of configuring it here, you may also configure it as a default across all jobs or use the built-in defaults (see further above under "max_strikes")
+      - By default, this check relies on the "qBittorrent is downloading metadata" message that qBittorrent surfaces in the \*arr queue. Other download clients (e.g. Transmission, Deluge) do not surface such a message, so a torrent stuck fetching metadata stays undetected (see [#57](https://github.com/ManiMatter/decluttarr/issues/57)).
+      - Set `detect_via_missing_size: true` to additionally flag, regardless of download client, queued items whose size is not yet known (size 0), which is the client-agnostic signature of "no metadata yet". This is debounced by max_strikes. Defaults to False to keep existing (qBittorrent) behavior unchanged.
 
 #### REMOVE_MISSING_FILES
 

--- a/src/jobs/remove_metadata_missing.py
+++ b/src/jobs/remove_metadata_missing.py
@@ -6,5 +6,20 @@ class RemoveMetadataMissing(RemovalJob):
     blocklist = True
 
     async def _find_affected_items(self):
+        # qBittorrent surfaces a dedicated *arr error message while fetching metadata.
         conditions = [("queued", "qBittorrent is downloading metadata")]
-        return self.queue_manager.filter_queue(self.queue, conditions)
+        affected_items = self.queue_manager.filter_queue(self.queue, conditions)
+
+        # Other clients (e.g. Transmission, Deluge) do not surface such a message, so a
+        # torrent stuck fetching metadata is invisible to the message-based check above
+        # (see #57). Opt-in fallback: also flag queued items whose size is not yet known
+        # (size == 0), which is the client-agnostic signature of "no metadata yet".
+        # Debounced by max_strikes like the rest of this job.
+        if getattr(self.job, "detect_via_missing_size", False):
+            seen = {id(item) for item in affected_items}
+            for item in self.queue_manager.filter_missing_size(self.queue):
+                if id(item) not in seen:
+                    affected_items.append(item)
+                    seen.add(id(item))
+
+        return affected_items

--- a/src/settings/_jobs.py
+++ b/src/settings/_jobs.py
@@ -14,6 +14,7 @@ class JobParams:
     max_concurrent_searches: int
     min_days_between_searches: int
     target_tags: list
+    detect_via_missing_size: bool = False
 
     def __init__(
         self,
@@ -25,6 +26,7 @@ class JobParams:
         max_concurrent_searches=None,
         min_days_between_searches=None,
         target_tags=None,
+        detect_via_missing_size=None,
     ):
         self.enabled = enabled
         self.keep_archives = keep_archives
@@ -34,6 +36,7 @@ class JobParams:
         self.max_concurrent_searches = max_concurrent_searches
         self.min_days_between_searches = min_days_between_searches
         self.target_tags = target_tags
+        self.detect_via_missing_size = detect_via_missing_size
 
         # Remove attributes that are None to keep the object clean
         self._remove_none_attributes()
@@ -86,6 +89,7 @@ class Jobs:
         )
         self.remove_metadata_missing = JobParams(
             max_strikes=self.job_defaults.max_strikes,
+            detect_via_missing_size=False,
         )
         self.remove_missing_files = JobParams()
         self.remove_orphans = JobParams()

--- a/src/utils/queue_manager.py
+++ b/src/utils/queue_manager.py
@@ -241,3 +241,21 @@ class QueueManager:
                     filtered_items.append(item)
                     break
         return filtered_items
+
+    @staticmethod
+    def filter_missing_size(queue: list[dict]) -> list[dict]:
+        """
+        Return queued items whose size is not yet known (no metadata fetched).
+
+        Unlike qBittorrent, clients such as Transmission or Deluge do not surface a
+        "downloading metadata" message in the *arr queue, so a torrent stuck fetching
+        metadata cannot be matched by message. Such items are reported by the *arr as
+        status "queued" with size 0. This client-agnostic check catches them (see #57).
+
+        The "size" key must be present so that incomplete items are not matched.
+        """
+        return [
+            item
+            for item in queue
+            if item.get("status") == "queued" and "size" in item and not item["size"]
+        ]

--- a/tests/jobs/test_remove_metadata_missing.py
+++ b/tests/jobs/test_remove_metadata_missing.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from src.jobs.remove_metadata_missing import RemoveMetadataMissing
@@ -88,6 +90,103 @@ from tests.jobs.utils import shared_fix_affected_items, shared_test_affected_ite
 async def test_find_affected_items(queue_data, expected_download_ids):
     # Arrange
     removal_job = shared_fix_affected_items(RemoveMetadataMissing, queue_data)
+
+    # Act and Assert
+    await shared_test_affected_items(removal_job, expected_download_ids)
+
+
+# Tests the opt-in, client-agnostic detection of items stuck without metadata
+# (status "queued" + size 0), e.g. on Transmission/Deluge which do not surface the
+# qBittorrent "downloading metadata" message in the *arr queue (see issue #57).
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("detect_via_missing_size", "queue_data", "expected_download_ids"),
+    [
+        # Disabled (default): a queued size-0 item is NOT flagged; only the qBit message is.
+        (
+            False,
+            [
+                {
+                    "id": 1,
+                    "downloadId": "a",
+                    "status": "queued",
+                    "size": 0,
+                    "errorMessage": None,
+                },
+                {
+                    "id": 2,
+                    "downloadId": "b",
+                    "status": "queued",
+                    "errorMessage": "qBittorrent is downloading metadata",
+                },
+            ],
+            ["b"],
+        ),
+        # Enabled: queued + size 0 is flagged; size > 0 and non-queued are left alone.
+        (
+            True,
+            [
+                {
+                    "id": 1,
+                    "downloadId": "a",
+                    "status": "queued",
+                    "size": 0,
+                    "errorMessage": None,
+                },
+                {
+                    "id": 2,
+                    "downloadId": "b",
+                    "status": "queued",
+                    "size": 1234,
+                    "errorMessage": None,
+                },
+                {
+                    "id": 3,
+                    "downloadId": "c",
+                    "status": "downloading",
+                    "size": 0,
+                    "errorMessage": None,
+                },
+            ],
+            ["a"],
+        ),
+        # Enabled: an item matching BOTH the qBit message and size 0 is not duplicated.
+        (
+            True,
+            [
+                {
+                    "id": 1,
+                    "downloadId": "a",
+                    "status": "queued",
+                    "size": 0,
+                    "errorMessage": "qBittorrent is downloading metadata",
+                },
+                {
+                    "id": 2,
+                    "downloadId": "b",
+                    "status": "queued",
+                    "size": 0,
+                    "errorMessage": None,
+                },
+            ],
+            ["a", "b"],
+        ),
+        # Enabled but no size key present (e.g. partial item): not matched.
+        (
+            True,
+            [
+                {"id": 1, "downloadId": "a", "status": "queued", "errorMessage": None},
+            ],
+            [],
+        ),
+    ],
+)
+async def test_find_affected_items_via_missing_size(
+    detect_via_missing_size, queue_data, expected_download_ids
+):
+    # Arrange
+    removal_job = shared_fix_affected_items(RemoveMetadataMissing, queue_data)
+    removal_job.job = MagicMock(detect_via_missing_size=detect_via_missing_size)
 
     # Act and Assert
     await shared_test_affected_items(removal_job, expected_download_ids)


### PR DESCRIPTION
## Problem

`remove_metadata_missing` matches a single hardcoded condition:

```python
conditions = [("queued", "qBittorrent is downloading metadata")]
```

That `errorMessage` is only surfaced in the *arr queue when the download client is **qBittorrent**. With **Transmission** (and Deluge), a torrent stuck *fetching metadata* surfaces **no** message: the *arr reports it as `status: "queued"`, `trackedDownloadStatus: "ok"`, `size: 0`, `errorMessage: null`. So it matches neither `remove_metadata_missing` nor `remove_stalled`, and lingers in the queue indefinitely.

This is exactly the behaviour reported in #57 ("with Transmission, no torrent gets detected as stalled/missing metadata"), where the reporter ultimately had to switch to qBittorrent. Issues #40 and #81 touch the same gap.

## Change

Adds an **opt-in**, client-agnostic fallback to the same job: `detect_via_missing_size` (default **`False`**, so existing qBittorrent setups are unchanged).

When enabled, the job *additionally* flags queued items whose size is not yet known (`size == 0`) — the client-agnostic signature of "no metadata fetched yet" — regardless of download client. It reuses the existing `max_strikes` debounce and the existing blocklist + redownload flow, so a stuck download is removed and the *arr re-grabs another release.

- `RemoveMetadataMissing._find_affected_items`: union with the new check, deduplicated (an item matching both the qBit message and `size == 0` is not counted twice).
- `QueueManager.filter_missing_size`: new helper. Requires the `size` key to be present, so partial/mocked items are never matched.
- `JobParams`: new `detect_via_missing_size: bool` option (validated/converted like the other job options; configurable via YAML or the env block notation).
- Tests: on/off, `size > 0` and non-queued ignored, dedup, and missing-`size`-key cases.
- README: documents the new option under `REMOVE_METADATA_MISSING`.

## Why opt-in / why size-based

The *arr queue exposes no Transmission-specific "downloading metadata" signal, so the only client-agnostic ground truth available without a dedicated Transmission integration is `size == 0`. Keeping it behind a flag (default off) avoids surprising qBittorrent users, since a torrent merely waiting behind a client's active-download limit can also be `queued` + `size 0`; the `max_strikes` debounce mitigates transient cases. This deliberately stays within decluttarr's "works without qBittorrent, just with fewer features" philosophy rather than adding a new download-client type.

## Validation

- Full suite: `198 → 202 passed` (4 new cases).
- `pylint` 10/10 on the changed modules (excluding environment-only import-errors); `black`/`isort` clean.
- Default behaviour byte-for-byte unchanged when the flag is off.