### PR TITLE
Degrade unreachable instances at startup instead of exiting the whole app

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from src.deletion_handler.deletion_handler import WatcherManager
 from src.job_manager import JobManager
 from src.settings.settings import Settings
 from src.utils.log_setup import logger
-from src.utils.startup import launch_steps
+from src.utils.startup import launch_steps, retry_degraded_instances
 
 settings = Settings()
 job_manager = JobManager(settings)
@@ -53,13 +53,18 @@ async def main():
     await launch_steps(settings)
 
     if settings.jobs.detect_deletions.enabled:
-        await WatcherManager(settings).setup()
+        await watch_manager.setup()
     # Start Cleaning
     while True:
         logger.info("-" * 50)
 
+        # Give degraded instances a chance to rejoin before this cycle's jobs
+        await retry_degraded_instances(settings, watch_manager)
+
         # Refresh qBit Cookies (SABnzbd doesn't need cookie refresh)
         for qbit in settings.download_clients.qbittorrent:
+            if not qbit.ready:
+                continue
             try:
                 await qbit.refresh_cookie()
             except Exception as err:  # noqa: BLE001
@@ -70,6 +75,8 @@ async def main():
 
         # Run script for each instance
         for arr in settings.instances:
+            if not arr.ready:  # skip was already logged by retry_degraded_instances
+                continue
             await job_manager.run_jobs(arr)
             logger.verbose("")
 

--- a/src/deletion_handler/deletion_handler.py
+++ b/src/deletion_handler/deletion_handler.py
@@ -99,35 +99,52 @@ class WatcherManager:
         for arr, folder_path in folders_to_watch:
             self.set_watcher(arr, folder_path)
 
+    async def setup_for_arr(self, arr):
+        """Set up deletion watchers for a single arr (e.g. one that rejoined after a degraded startup)."""
+        if self.loop is None:
+            self.loop = asyncio.get_running_loop()
+        for folder_path in await self.get_folders_to_watch_for_arr(arr):
+            self.set_watcher(arr, folder_path)
+
     async def get_folders_to_watch(self):
         """Gets from all arrs the root folders and lists those that are accessible for the arr, and have present for decluttarr."""
         folders_to_watch = []
         logger.verbose("")
         logger.verbose("*** Setting up monitoring for deletions ***")
         for arr in self.settings.instances:
-            if arr.arr_type not in (
-                "sonarr",
-                "radarr",
-            ):  # only working for sonarr / radarr for now
-                continue
-            root_folders = await arr.get_root_folders()
+            for folder_path in await self.get_folders_to_watch_for_arr(arr):
+                folders_to_watch.append((arr, folder_path))
 
-            for folder in root_folders:
-                if folder.get("accessible") and "path" in folder:
-                    path = Path(folder["path"])
-                    if path.exists():
-                        folders_to_watch.append((arr, folder["path"]))
-                    else:
-                        logger.warning(
-                            f"Job 'detect_deletions' on {arr.name} ({arr.base_url}) does not have access to this path and will not monitor it: '{path}'"
-                        )
+        return folders_to_watch
+
+    async def get_folders_to_watch_for_arr(self, arr):
+        """Root folder paths of one arr that are accessible for both the arr and decluttarr."""
+        folders_to_watch = []
+        if arr.arr_type not in (
+            "sonarr",
+            "radarr",
+        ):  # only working for sonarr / radarr for now
+            return folders_to_watch
+        if not arr.ready:  # degraded instance; watchers are added when it rejoins
+            return folders_to_watch
+        root_folders = await arr.get_root_folders()
+
+        for folder in root_folders:
+            if folder.get("accessible") and "path" in folder:
+                path = Path(folder["path"])
+                if path.exists():
+                    folders_to_watch.append(folder["path"])
+                else:
+                    logger.warning(
+                        f"Job 'detect_deletions' on {arr.name} ({arr.base_url}) does not have access to this path and will not monitor it: '{path}'"
+                    )
+                    logger.info(
+                        ">>> 💡 Tip: Make sure that the paths in decluttarr and in your arr instance are identical."
+                    )
+                    if self.settings.envs.in_docker:
                         logger.info(
-                            ">>> 💡 Tip: Make sure that the paths in decluttarr and in your arr instance are identical."
+                            ">>> 💡 Tip: Make sure decluttarr and your arr instance have the same mount points"
                         )
-                        if self.settings.envs.in_docker:
-                            logger.info(
-                                ">>> 💡 Tip: Make sure decluttarr and your arr instance have the same mount points"
-                            )
 
         return folders_to_watch
 

--- a/src/job_manager.py
+++ b/src/job_manager.py
@@ -56,6 +56,9 @@ class JobManager:
             )
 
             for client in download_clients:
+                if not client.ready:
+                    continue
+
                 # Get jobs for this client
                 download_client_jobs = self._get_download_client_jobs_for_client(
                     client,
@@ -150,6 +153,8 @@ class JobManager:
 
     async def _check_client_connection_status(self, clients):
         for client in clients:
+            if not client.ready:  # never-set-up client must not veto or be polled
+                continue
             logger.debug(
                 f"job_manager.py/_check_client_connection_status: Checking if {client.name} is connected",
             )

--- a/src/jobs/removal_handler.py
+++ b/src/jobs/removal_handler.py
@@ -44,6 +44,8 @@ class RemovalHandler:
             f"Job '{self.job_name}' triggered obsolete-tagging: {affected_download['title']}"
         )
         for qbit in self.settings.download_clients.qbittorrent:
+            if not qbit.ready:
+                continue
             await qbit.set_tag(
                 tags=[self.settings.general.obsolete_tag], hashes=[download_id]
             )
@@ -55,12 +57,12 @@ class RemovalHandler:
         download_client_name = affected_download["downloadClient"]
         _, download_client_type = (
             self.settings.download_clients.get_download_client_by_name(
-                download_client_name
+                download_client_name, ready_only=True
             )
         )
 
         if download_client_type != "qbittorrent":
-            return "remove"  # handling is only implemented for qbit
+            return "remove"  # handling is only implemented for qbit (and only if ready)
 
         if len(self.settings.download_clients.qbittorrent) == 0:
             return "remove"  # qbit not configured, thus can't tag

--- a/src/jobs/removal_job.py
+++ b/src/jobs/removal_job.py
@@ -50,6 +50,7 @@ class RemovalJob(ABC):
 
         # -- Checks --
         self._ignore_protected()
+        self._ignore_degraded_client_downloads()
         if self.max_strikes:
             self.affected_downloads = self.strikes_handler.filter_strike_exceeds(
                 self.affected_downloads, self.queue
@@ -75,6 +76,36 @@ class RemovalJob(ABC):
             for download_id, queue_items in self.affected_downloads.items()
             if download_id not in self.arr.tracker.protected
         }
+
+    def _ignore_degraded_client_downloads(self):
+        """Fail-closed: never remove a download whose configured client is degraded.
+
+        A degraded (not-ready) download client can't be queried for protection
+        status (protected tag, private/public tracker), so its downloads must be
+        left untouched rather than deleted blindly. Downloads on healthy clients,
+        or on clients not configured in decluttarr, are unaffected.
+        """
+        safe = {}
+        skipped = 0
+        for download_id, download in self.affected_downloads.items():
+            # download is the grouped metadata dict from group_by_download_id.
+            client_name = download.get("downloadClient")
+            client = None
+            if client_name:
+                client, _ = self.settings.download_clients.get_download_client_by_name(
+                    client_name
+                )
+            if client is not None and not client.ready:
+                skipped += 1
+                continue
+            safe[download_id] = download
+
+        if skipped:
+            logger.warning(
+                f">>> {self.job_name}: skipped {skipped} download(s) on {self.arr.name} "
+                "whose download client is degraded (protection can't be verified; left untouched).",
+            )
+        self.affected_downloads = safe
 
     @abstractmethod  # Implemented on level of each removal job
     async def _find_affected_items(self) -> None:

--- a/src/jobs/remove_bad_files.py
+++ b/src/jobs/remove_bad_files.py
@@ -62,7 +62,7 @@ class RemoveBadFiles(RemovalJob):
 
             download_client, download_client_type = (
                 self.settings.download_clients.get_download_client_by_name(
-                    download_client_name
+                    download_client_name, ready_only=True
                 )
             )
             if not download_client or not download_client_type:

--- a/src/jobs/remove_slow.py
+++ b/src/jobs/remove_slow.py
@@ -168,7 +168,7 @@ class RemoveSlow(RemovalJob):
             download_client_name = item["downloadClient"]
             download_client, download_client_type = (
                 self.settings.download_clients.get_download_client_by_name(
-                    download_client_name
+                    download_client_name, ready_only=True
                 )
             )
             item["download_client"] = download_client

--- a/src/settings/_download_clients.py
+++ b/src/settings/_download_clients.py
@@ -81,11 +81,16 @@ class DownloadClients:
                 seen.add(name.lower())
 
     def get_download_client_by_name(
-        self, name: str, download_client_type: str | None = None
+        self,
+        name: str,
+        download_client_type: str | None = None,
+        ready_only: bool = False,
     ):
         """
         Retrieve the download client and download client type by its name.
         If download_client_type is provided, search only in that type.
+        If ready_only is True, a client that failed its startup check (not ready)
+        is treated as unavailable, so degraded clients never get called from jobs.
         """
         name_lower = name.lower()
         types_to_search = (
@@ -97,6 +102,8 @@ class DownloadClients:
 
             for download_client in download_clients:
                 if download_client.name.lower() == name_lower:
+                    if ready_only and not getattr(download_client, "ready", False):
+                        return None, None
                     return download_client, client_type
 
         return None, None

--- a/src/settings/_download_clients_qbit.py
+++ b/src/settings/_download_clients_qbit.py
@@ -2,12 +2,19 @@ from packaging import version
 from requests.cookies import RequestsCookieJar
 
 from src.settings._constants import ApiEndpoints, MinVersions
-from src.utils.common import extract_json_from_response, make_request, wait_and_exit
+from src.utils.common import (
+    extract_json_from_response,
+    is_definitive_setup_error,
+    make_request,
+)
 from src.utils.log_setup import logger
 
 
 class QbitError(Exception):
-    pass
+    def __init__(self, message, tip="", definitive=False):
+        super().__init__(message)
+        self.tip = tip
+        self.definitive = definitive
 
 
 class QbitClients(list):
@@ -39,6 +46,10 @@ class QbitClient:
     cookie: dict[str, str] = None
     version: str = None
     bandwidth_usage: int = 0
+    ready: bool = False
+    failure_kind: str = None  # None | "transient" | "definitive"
+    last_error: str = None
+    setup_tip: str = ""
 
     def __init__(
         self,
@@ -160,7 +171,7 @@ class QbitClient:
                 f"Please update qBittorrent to at least version {min_version}. Current version: {self.version}",
             )
             error = f"qBittorrent version {self.version} is too old. Please update."
-            raise QbitError(error)
+            raise QbitError(error, definitive=True)
         if version.parse(self.version) < version.parse("5.0.0"):
             logger.info(
                 "[Tip!] Consider upgrading to qBittorrent v5.0.0 or newer to reduce network overhead.",
@@ -228,7 +239,7 @@ class QbitClient:
                 )
 
     async def check_qbit_reachability(self):
-        """Check if the qBittorrent URL is reachable."""
+        """Check if the qBittorrent URL is reachable (and the credentials work)."""
         try:
             logger.debug(
                 "_download_clients_qBit.py/check_qbit_reachability: Checking if qbit is reachable",
@@ -239,7 +250,7 @@ class QbitClient:
                 "password": getattr(self, "password", ""),
             }
             headers = {"content-type": "application/x-www-form-urlencoded"}
-            await make_request(
+            response = await make_request(
                 "post",
                 endpoint,
                 self.settings,
@@ -249,11 +260,21 @@ class QbitClient:
                 log_error=False,
                 ignore_test_run=True,
             )
-
         except Exception as e:  # noqa: BLE001
             tip = "💡 Tip: Did you specify the URL (and username/password if required) correctly?"
-            logger.error(f"-- | qBittorrent\n❗️ {e}\n{tip}\n")
-            wait_and_exit()
+            if str(e) != self.last_error:  # Only report new failure modes in full
+                logger.error(f"-- | qBittorrent\n❗️ {e}\n{tip}\n")
+            raise QbitError(e, tip=tip) from e
+
+        # Bad credentials: qBit answers HTTP 200 with the body "Fails." Treat this
+        # as a definitive config error so we don't retry-loop every cycle and get
+        # the source IP banned by qBittorrent's failed-login protection.
+        if getattr(response, "text", None) == "Fails.":
+            tip = "💡 Tip: Check the qBittorrent username/password."
+            error = "qBittorrent login failed (incorrect username/password)."
+            if error != self.last_error:
+                logger.error(f"-- | qBittorrent\n❗️ {error}\n{tip}\n")
+            raise QbitError(error, tip=tip, definitive=True)
 
     async def check_connected(self):
         """Check if the qBittorrent is connected to internet."""
@@ -283,26 +304,38 @@ class QbitClient:
         return True
 
     async def setup(self):
-        """Perform the qBittorrent setup by calling relevant managers."""
-        # Check reachabilty
-        await self.check_qbit_reachability()
-
-        # Refresh the qBittorrent cookie first
-        await self.refresh_cookie()
-
+        """Perform the qBittorrent setup; degrade instead of exiting on failure."""
         try:
+            await self.check_qbit_reachability()
+
+            # Refresh the qBittorrent cookie first
+            await self.refresh_cookie()
+
             # Fetch version and validate it
             await self.fetch_version()
             await self.validate_version()
-            logger.info(f"OK | qBittorrent ({self.base_url})")
-        except QbitError as e:
-            logger.error(f"qBittorrent version check failed: {e}")
-            wait_and_exit()  # Exit if version check fails
 
-        # Continue with other setup tasks regardless of version check result
-        await self.create_required_tags()
-        await self.set_unwanted_folder()
-        await self.warn_no_bandwidth_limit_set()
+            await self.create_required_tags()
+            await self.set_unwanted_folder()
+            await self.warn_no_bandwidth_limit_set()
+
+            logger.info(f"OK | qBittorrent ({self.base_url})")
+            self.ready = True
+            self.failure_kind = None
+            self.last_error = None
+            self.setup_tip = ""
+        except Exception as e:  # noqa: BLE001
+            if not isinstance(e, QbitError) and str(e) != self.last_error:
+                logger.error(
+                    f"Unhandled error during qBittorrent setup: {e}", exc_info=True
+                )
+            self.ready = False
+            self.failure_kind = (
+                "definitive" if is_definitive_setup_error(e) else "transient"
+            )
+            self.last_error = str(e)
+            self.setup_tip = getattr(e, "tip", "")
+        return self.ready
 
     async def get_protected_and_private(self):
         """Fetch torrents from qBittorrent and checks for protected and private status."""
@@ -428,7 +461,6 @@ class QbitClient:
             cookies=self.cookie,
         )
         return response.json()
-
 
     async def get_torrent_files(self, download_id):
         # this may not work if the wrong qbit

--- a/src/settings/_download_clients_sabnzbd.py
+++ b/src/settings/_download_clients_sabnzbd.py
@@ -1,12 +1,15 @@
 from packaging import version
 
 from src.settings._constants import MinVersions
-from src.utils.common import make_request, wait_and_exit
+from src.utils.common import is_definitive_setup_error, make_request
 from src.utils.log_setup import logger
 
 
 class SabnzbdError(Exception):
-    pass
+    def __init__(self, message, tip="", definitive=False):
+        super().__init__(message)
+        self.tip = tip
+        self.definitive = definitive
 
 
 class SabnzbdClients(list):
@@ -36,6 +39,10 @@ class SabnzbdClient:
     """Represents a single SABnzbd client."""
 
     version: str = None
+    ready: bool = False
+    failure_kind: str = None  # None | "transient" | "definitive"
+    last_error: str = None
+    setup_tip: str = ""
 
     def __init__(
         self,
@@ -105,16 +112,16 @@ class SabnzbdClient:
                 f"Please update SABnzbd to at least version {min_version}. Current version: {self.version}",
             )
             error = f"SABnzbd version {self.version} is too old. Please update."
-            raise SabnzbdError(error)
+            raise SabnzbdError(error, definitive=True)
 
     async def check_sabnzbd_reachability(self):
-        """Check if the SABnzbd URL is reachable."""
+        """Check if the SABnzbd URL is reachable (and the API key works)."""
         try:
             logger.debug(
                 "_download_clients_sabnzbd.py/check_sabnzbd_reachability: Checking if SABnzbd is reachable"
             )
             params = {"mode": "version", "apikey": self.api_key, "output": "json"}
-            await make_request(
+            response = await make_request(
                 "get",
                 self.api_url,
                 self.settings,
@@ -123,11 +130,24 @@ class SabnzbdClient:
                 log_error=False,
                 ignore_test_run=True,
             )
-
         except Exception as e:  # noqa: BLE001
             tip = "💡 Tip: Did you specify the URL and API key correctly?"
-            logger.error(f"-- | SABnzbd\n❗️ {e}\n{tip}\n")
-            wait_and_exit()
+            if str(e) != self.last_error:  # Only report new failure modes in full
+                logger.error(f"-- | SABnzbd\n❗️ {e}\n{tip}\n")
+            raise SabnzbdError(e, tip=tip) from e
+
+        # Bad API key: SABnzbd answers HTTP 200 with {"error": "API Key Incorrect"}.
+        # Treat as a definitive config error so we don't retry-loop forever.
+        try:
+            error_msg = response.json().get("error")
+        except (ValueError, AttributeError):
+            error_msg = None
+        if error_msg:
+            tip = "💡 Tip: Check the SABnzbd API key."
+            error = f"SABnzbd rejected the request: {error_msg}"
+            if error != self.last_error:
+                logger.error(f"-- | SABnzbd\n❗️ {error}\n{tip}\n")
+            raise SabnzbdError(error, tip=tip, definitive=True)
 
     async def check_connected(self):
         """Check if SABnzbd is connected and operational."""
@@ -148,18 +168,31 @@ class SabnzbdClient:
         return "status" in status_data
 
     async def setup(self):
-        """Perform the SABnzbd setup by calling relevant managers."""
-        # Check reachability
-        await self.check_sabnzbd_reachability()
-
+        """Perform the SABnzbd setup; degrade instead of exiting on failure."""
         try:
+            await self.check_sabnzbd_reachability()
+
             # Fetch version and validate it
             await self.fetch_version()
             await self.validate_version()
+
             logger.info(f"OK | SABnzbd ({self.base_url})")
-        except SabnzbdError as e:
-            logger.error(f"SABnzbd version check failed: {e}")
-            wait_and_exit()  # Exit if version check fails
+            self.ready = True
+            self.failure_kind = None
+            self.last_error = None
+            self.setup_tip = ""
+        except Exception as e:  # noqa: BLE001
+            if not isinstance(e, SabnzbdError) and str(e) != self.last_error:
+                logger.error(
+                    f"Unhandled error during SABnzbd setup: {e}", exc_info=True
+                )
+            self.ready = False
+            self.failure_kind = (
+                "definitive" if is_definitive_setup_error(e) else "transient"
+            )
+            self.last_error = str(e)
+            self.setup_tip = getattr(e, "tip", "")
+        return self.ready
 
     async def get_queue_items(self):
         """Fetch queue items from SABnzbd."""

--- a/src/settings/_instances.py
+++ b/src/settings/_instances.py
@@ -13,7 +13,12 @@ from src.settings._constants import (
     RefreshItemCommand,
     RefreshItemKey,
 )
-from src.utils.common import extract_json_from_response, make_request, wait_and_exit
+from src.utils.common import (
+    extract_json_from_response,
+    is_definitive_setup_error,
+    make_request,
+    wait_and_exit,
+)
 from src.utils.log_setup import logger
 
 
@@ -42,6 +47,8 @@ class Tracker:
         private_downloads = []
 
         for qbit in settings.download_clients.qbittorrent:
+            if not qbit.ready:
+                continue
             protected, private = await qbit.get_protected_and_private()
             protected_downloads.extend(protected)
             private_downloads.extend(private)
@@ -51,7 +58,10 @@ class Tracker:
 
 
 class ArrError(Exception):
-    pass
+    def __init__(self, message, tip="", definitive=False):
+        super().__init__(message)
+        self.tip = tip
+        self.definitive = definitive
 
 
 class ArrInstances(list):
@@ -135,6 +145,10 @@ class ArrInstance:
 
     version: str = None
     name: str = None
+    ready: bool = False
+    failure_kind: str = None  # None | "transient" | "definitive"
+    last_error: str = None
+    setup_tip: str = ""
 
     def __init__(self, settings, arr_type: str, base_url: str, api_key: str, timeout: int | None = None):
         if not base_url:
@@ -186,7 +200,8 @@ class ArrInstance:
                 "> Details: https://github.com/ManiMatter/decluttarr/issues/132)",
             )
             error = "Not English"
-            raise ArrError(error)
+            tip = f"💡 Tip: Set the UI language to English in {self.name} (under Settings/UI)"
+            raise ArrError(error, tip=tip, definitive=True)
 
     def _check_min_version(self, status):
         """Check if ARR instance meets minimum version requirements."""
@@ -243,11 +258,12 @@ class ArrInstance:
             else:
                 tip = ""
 
-            logger.error(f"-- | {self.arr_type} ({self.base_url})\n❗️ {e}\n{tip}\n")
-            raise ArrError(e) from e
+            if str(e) != self.last_error:  # Only report new failure modes in full
+                logger.error(f"-- | {self.arr_type} ({self.base_url})\n❗️ {e}\n{tip}\n")
+            raise ArrError(e, tip=tip) from e
 
     async def setup(self):
-        """Check on specific ARR instance."""
+        """Check on specific ARR instance; degrade instead of exiting on failure."""
         try:
             status = await self._check_reachability()
             self.name = status.get("instanceName", self.arr_type)
@@ -260,10 +276,20 @@ class ArrInstance:
             logger.debug(f"Current version of {self.name}: {self.version}")
             await self._check_matching_decluttarr_download_clients()
 
+            self.ready = True
+            self.failure_kind = None
+            self.last_error = None
+            self.setup_tip = ""
         except Exception as e:  # noqa: BLE001
-            if not isinstance(e, ArrError):
+            if not isinstance(e, ArrError) and str(e) != self.last_error:
                 logger.error(f"Unhandled error: {e}", exc_info=True)
-            wait_and_exit()
+            self.ready = False
+            self.failure_kind = (
+                "definitive" if is_definitive_setup_error(e) else "transient"
+            )
+            self.last_error = str(e)
+            self.setup_tip = getattr(e, "tip", "")
+        return self.ready
 
     async def fetch_arr_download_clients(self) -> list[dict[str, object]]:
         """Fetch the list of download clients from the *arr API."""

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -100,6 +100,18 @@ def wait_and_exit(seconds=30):
     sys.exit()
 
 
+def is_definitive_setup_error(exc):
+    """Definitive = a configuration error that cannot heal without user action."""
+    for candidate in (exc, exc.__cause__):
+        if getattr(candidate, "definitive", False):
+            return True
+        if isinstance(candidate, requests.exceptions.HTTPError):
+            response = getattr(candidate, "response", None)
+            if response is not None and response.status_code in (401, 403):
+                return True
+    return False
+
+
 def extract_json_from_response(response, key: str | None = None):
     try:
         data = response.json()

--- a/src/utils/startup.py
+++ b/src/utils/startup.py
@@ -1,6 +1,22 @@
 import warnings
 
+from src.utils.common import wait_and_exit
 from src.utils.log_setup import logger
+
+
+def _all_units(settings):
+    """All startup-checked units: download clients and arr instances."""
+    return [
+        *settings.download_clients.qbittorrent,
+        *settings.download_clients.sabnzbd,
+        *settings.instances,
+    ]
+
+
+def _unit_label(unit):
+    """Printable identity; falls back to arr_type while name is not yet known."""
+    name = getattr(unit, "name", None) or getattr(unit, "arr_type", "")
+    return f"{name} ({unit.base_url})"
 
 
 def show_welcome(settings):
@@ -78,3 +94,56 @@ async def launch_steps(settings):
     settings.instances.check_any_arrs()
     for arr in settings.instances:
         await arr.setup()
+
+    _exit_if_all_failed_definitively(settings)
+
+
+def _exit_if_all_failed_definitively(settings):
+    """Exit only if every configured unit failed with a non-recoverable config error.
+
+    A unit that failed transiently (timeout, connection) keeps the app alive:
+    it is retried every cycle and rejoins once its server responds.
+    """
+    units = _all_units(settings)
+    if units and all(
+        not unit.ready and unit.failure_kind == "definitive" for unit in units
+    ):
+        logger.error(
+            "All configured instances and download clients failed their startup "
+            "checks with configuration errors that cannot self-heal. "
+            "Please review the errors above, fix your configuration, and restart.",
+        )
+        wait_and_exit()
+
+
+async def retry_degraded_instances(settings, watch_manager=None):
+    """Re-attempt setup of degraded units each cycle; report definitive failures."""
+    for unit in _all_units(settings):
+        if unit.ready:
+            continue
+        if unit.failure_kind == "definitive":
+            logger.error(
+                f"SKIP | {_unit_label(unit)}: configuration error - {unit.last_error}. "
+                f"Fix configuration and restart. {unit.setup_tip}".rstrip(),
+            )
+            continue
+        if await unit.setup():
+            logger.info(
+                f"REJOINED | {_unit_label(unit)}: setup succeeded - resuming jobs"
+            )
+            if (
+                watch_manager
+                and getattr(unit, "arr_type", None) in ("sonarr", "radarr")
+                and settings.jobs.detect_deletions.enabled
+            ):
+                await watch_manager.setup_for_arr(unit)
+        else:
+            logger.warning(
+                f"SKIP | {_unit_label(unit)}: not reachable - {unit.last_error} "
+                f"(will retry next cycle)",
+            )
+
+    # A transient unit may have turned definitive on retry (e.g. a slow qBit
+    # finally answered, revealing a bad key). Re-evaluate so the app doesn't spin
+    # forever with nothing left that can heal.
+    _exit_if_all_failed_definitively(settings)

--- a/tests/deletion_handler/test_deletion_handler.py
+++ b/tests/deletion_handler/test_deletion_handler.py
@@ -165,6 +165,7 @@ async def test_file_deletion_triggers_handler_with_watchermanager(tmp_path):
             self.name = "Test"
             self.arr_type = "sonarr"
             self.base_url = "http://localhost"
+            self.ready = True
             self.called_paths = []
             self.refreshed_ids = []
 
@@ -210,3 +211,20 @@ async def test_file_deletion_triggers_handler_with_watchermanager(tmp_path):
 
     finally:
         watcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_get_folders_to_watch_skips_not_ready_arr():
+    arr_mock = MagicMock()
+    arr_mock.arr_type = "sonarr"
+    arr_mock.ready = False
+    arr_mock.get_root_folders = AsyncMock()
+
+    settings = MagicMock()
+    settings.instances = [arr_mock]
+    watcher_manager = WatcherManager(settings)
+
+    folders = await watcher_manager.get_folders_to_watch()
+
+    assert folders == []
+    arr_mock.get_root_folders.assert_not_awaited()

--- a/tests/jobs/test_removal_handler.py
+++ b/tests/jobs/test_removal_handler.py
@@ -52,3 +52,23 @@ async def test_get_handling_method(
         "A", affected_download
     )
     assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_tag_as_obsolete_skips_not_ready_qbit():
+    """A degraded qbit must not have set_tag called during obsolete-tagging."""
+    ready_qbit = AsyncMock()
+    ready_qbit.ready = True
+    degraded_qbit = AsyncMock()
+    degraded_qbit.ready = False
+
+    arr = AsyncMock()
+    settings = MagicMock()
+    settings.download_clients.qbittorrent = [ready_qbit, degraded_qbit]
+    settings.general.obsolete_tag = "Obsolete"
+
+    handler = RemovalHandler(arr=arr, settings=settings, job_name="remove_stalled")
+    await handler._tag_as_obsolete({"title": "Some.Release"}, download_id="hash1")
+
+    ready_qbit.set_tag.assert_awaited_once()
+    degraded_qbit.set_tag.assert_not_awaited()

--- a/tests/jobs/test_removal_job.py
+++ b/tests/jobs/test_removal_job.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from src.jobs.remove_stalled import RemoveStalled
+from src.utils.queue_manager import QueueManager
+
+
+def _job_with_clients():
+    """A RemovalJob (via a concrete subclass) whose settings resolve clients by name."""
+    job = RemoveStalled.__new__(RemoveStalled)
+    job.job_name = "remove_stalled"
+    job.arr = MagicMock()
+    job.arr.name = "Sonarr"
+
+    ready = SimpleNamespace(name="qbit-ready", ready=True)
+    degraded = SimpleNamespace(name="qbit-degraded", ready=False)
+
+    def resolver(name, *args, **kwargs):
+        return {
+            "qbit-ready": (ready, "qbittorrent"),
+            "qbit-degraded": (degraded, "qbittorrent"),
+        }.get(name, (None, None))
+
+    job.settings = MagicMock()
+    job.settings.download_clients.get_download_client_by_name.side_effect = resolver
+    return job
+
+
+def test_ignore_degraded_client_downloads_is_fail_closed():
+    """Downloads on a degraded client are left untouched; healthy and
+    unconfigured clients are unaffected (this is the guard that prevents the
+    data-loss scenario where a degraded qBit's protected torrents get deleted).
+
+    affected_downloads is built via the real group_by_download_id so the grouped
+    dict shape is exercised (a list-shaped fixture would hide a KeyError)."""
+    job = _job_with_clients()
+    grouped = QueueManager.group_by_download_id(
+        None,
+        [
+            {"downloadId": "on_ready", "id": 1, "downloadClient": "qbit-ready"},
+            {"downloadId": "on_degraded", "id": 2, "downloadClient": "qbit-degraded"},
+            {
+                "downloadId": "on_unconfigured",
+                "id": 3,
+                "downloadClient": "other-client",
+            },
+        ],
+    )
+    job.affected_downloads = grouped
+
+    job._ignore_degraded_client_downloads()
+
+    assert "on_ready" in job.affected_downloads  # healthy -> still removable
+    assert "on_degraded" not in job.affected_downloads  # degraded -> protected
+    assert "on_unconfigured" in job.affected_downloads  # unconfigured -> unchanged

--- a/tests/jobs/test_remove_slow.py
+++ b/tests/jobs/test_remove_slow.py
@@ -391,3 +391,45 @@ async def test_find_affected_items_simple(queue_item, should_be_affected):
         assert (
             not affected_items
         ), f"Item {queue_item.get('downloadId')} should NOT be affected"
+
+
+@pytest.mark.asyncio
+async def test_add_download_client_resolves_ready_only():
+    """A not-ready client resolves to None so downstream job logic skips it."""
+    job = RemoveSlow.__new__(RemoveSlow)
+    job.settings = MagicMock()
+    job.settings.download_clients.get_download_client_by_name.return_value = (
+        None,
+        None,
+    )
+    job.queue = [{"downloadClient": "qBittorrent"}]
+
+    await job.add_download_client_to_queue_items()
+
+    job.settings.download_clients.get_download_client_by_name.assert_called_once_with(
+        "qBittorrent", ready_only=True
+    )
+    assert job.queue[0]["download_client"] is None
+    assert job.queue[0]["download_client_type"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_bandwidth_usage_skips_degraded_client():
+    """A degraded client (mapped to None) must not have set_bandwidth_usage called."""
+    job = RemoveSlow.__new__(RemoveSlow)
+    job.queue = [{"download_client": None, "download_client_type": None}]
+
+    # Should be a no-op — no client to call, no exception.
+    await job.update_bandwidth_usage()
+
+
+@pytest.mark.asyncio
+async def test_update_bandwidth_usage_calls_ready_qbit():
+    """A ready qbit client still gets its bandwidth refreshed (regression)."""
+    client = AsyncMock()
+    job = RemoveSlow.__new__(RemoveSlow)
+    job.queue = [{"download_client": client, "download_client_type": "qbittorrent"}]
+
+    await job.update_bandwidth_usage()
+
+    client.set_bandwidth_usage.assert_awaited_once()

--- a/tests/settings/test_download_clients.py
+++ b/tests/settings/test_download_clients.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+
+from src.settings._download_clients import DownloadClients
+
+
+def _clients(qbits):
+    """A DownloadClients instance with the given qbit list (bypassing __init__)."""
+    dc = DownloadClients.__new__(DownloadClients)
+    dc.qbittorrent = qbits
+    dc.sabnzbd = []
+    return dc
+
+
+def test_ready_only_returns_ready_client():
+    client = SimpleNamespace(name="qBittorrent", ready=True)
+    dc = _clients([client])
+    assert dc.get_download_client_by_name("qBittorrent", ready_only=True) == (
+        client,
+        "qbittorrent",
+    )
+
+
+def test_ready_only_skips_not_ready_client():
+    client = SimpleNamespace(name="qBittorrent", ready=False)
+    dc = _clients([client])
+    # A degraded client is treated as unavailable so jobs never call it.
+    assert dc.get_download_client_by_name("qBittorrent", ready_only=True) == (
+        None,
+        None,
+    )
+
+
+def test_default_ignores_readiness():
+    # Backward compatibility: without ready_only, readiness is not considered.
+    client = SimpleNamespace(name="qBittorrent", ready=False)
+    dc = _clients([client])
+    assert dc.get_download_client_by_name("qBittorrent") == (client, "qbittorrent")
+
+
+def test_unknown_name_returns_none():
+    client = SimpleNamespace(name="qBittorrent", ready=True)
+    dc = _clients([client])
+    assert dc.get_download_client_by_name("does-not-exist", ready_only=True) == (
+        None,
+        None,
+    )

--- a/tests/settings/test_download_clients_qbit.py
+++ b/tests/settings/test_download_clients_qbit.py
@@ -1,6 +1,6 @@
 import pytest
-
 from requests.cookies import RequestsCookieJar
+
 from src.settings._download_clients_qbit import QbitClient, QbitError
 
 
@@ -38,3 +38,76 @@ def test_extract_sid_failures(cookies):
 
     with pytest.raises(QbitError, match="No qBit cookie found"):
         QbitClient.extract_sid(jar)
+
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import requests
+
+
+@pytest.mark.asyncio
+async def test_setup_reachability_timeout_marks_transient():
+    settings = MagicMock()
+    client = QbitClient(settings, base_url="http://qbit:8080")
+
+    with patch(
+        "src.settings._download_clients_qbit.make_request",
+        new_callable=AsyncMock,
+        side_effect=requests.exceptions.ReadTimeout("Read timed out."),
+    ):
+        result = await client.setup()
+
+    assert result is False
+    assert client.ready is False
+    assert client.failure_kind == "transient"
+    assert "Read timed out." in client.last_error
+
+
+@pytest.mark.asyncio
+async def test_setup_old_version_marks_definitive():
+    settings = MagicMock()
+    settings.min_versions.qbittorrent = "4.3.0"
+    client = QbitClient(settings, base_url="http://qbit:8080")
+    client.check_qbit_reachability = AsyncMock()
+    client.refresh_cookie = AsyncMock()
+    client.fetch_version = AsyncMock()
+    client.version = "3.0.0"
+
+    await client.setup()
+
+    assert client.ready is False
+    assert client.failure_kind == "definitive"
+
+
+@pytest.mark.asyncio
+async def test_setup_cookie_refresh_failure_marks_transient():
+    settings = MagicMock()
+    client = QbitClient(settings, base_url="http://qbit:8080")
+    client.check_qbit_reachability = AsyncMock()
+    client.refresh_cookie = AsyncMock(
+        side_effect=QbitError(ConnectionError("Login failed."))
+    )
+
+    await client.setup()
+
+    assert client.ready is False
+    assert client.failure_kind == "transient"
+
+
+@pytest.mark.asyncio
+async def test_setup_bad_password_marks_definitive():
+    """Wrong qBit password (HTTP 200 + 'Fails.') is definitive, not retried forever."""
+    settings = MagicMock()
+    client = QbitClient(
+        settings, base_url="http://qbit:8080", username="u", password="wrong"
+    )
+    resp = MagicMock(text="Fails.")
+    with patch(
+        "src.settings._download_clients_qbit.make_request",
+        new_callable=AsyncMock,
+        return_value=resp,
+    ):
+        await client.setup()
+
+    assert client.ready is False
+    assert client.failure_kind == "definitive"

--- a/tests/settings/test_instances.py
+++ b/tests/settings/test_instances.py
@@ -1,8 +1,32 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import requests
 
 from src.settings._instances import ArrInstance
+
+
+def _make_settings(min_version="4.0.0"):
+    settings = MagicMock()
+    settings.min_versions.sonarr = min_version
+    return settings
+
+
+def _response(json_data):
+    response = MagicMock()
+    response.json = MagicMock(return_value=json_data)
+    return response
+
+
+def _healthy_responses(app_name="Sonarr", app_version="9.9.9", ui_language=1):
+    """Responses for the three make_request calls in a full successful setup."""
+    return [
+        _response(
+            {"instanceName": "MockSonarr", "appName": app_name, "version": app_version}
+        ),
+        _response({"uiLanguage": ui_language}),
+        _response([]),  # downloadclient list
+    ]
 
 
 @pytest.mark.asyncio
@@ -61,3 +85,117 @@ async def test_get_refresh_item_by_path_returns_correct_item():
 
         mock_method.assert_awaited_once()
         assert result == {"id": 456, "path": "/media/folder2"}
+
+
+@pytest.mark.asyncio
+async def test_setup_timeout_marks_transient_and_does_not_exit():
+    arr = ArrInstance(_make_settings(), "sonarr", "http://sonarr/", "test_key")
+
+    with (
+        patch(
+            "src.settings._instances.make_request",
+            new_callable=AsyncMock,
+            side_effect=requests.exceptions.ReadTimeout("Read timed out."),
+        ),
+        patch("src.settings._instances.wait_and_exit") as mock_exit,
+    ):
+        result = await arr.setup()
+
+    mock_exit.assert_not_called()
+    assert result is False
+    assert arr.ready is False
+    assert arr.failure_kind == "transient"
+    assert "Read timed out." in arr.last_error
+
+
+@pytest.mark.asyncio
+async def test_setup_401_marks_definitive():
+    http_error = requests.exceptions.HTTPError("401 Client Error")
+    http_error.response = MagicMock(status_code=401)
+
+    arr = ArrInstance(_make_settings(), "sonarr", "http://sonarr/", "test_key")
+
+    with (
+        patch(
+            "src.settings._instances.make_request",
+            new_callable=AsyncMock,
+            side_effect=http_error,
+        ),
+        patch("src.settings._instances.wait_and_exit") as mock_exit,
+    ):
+        await arr.setup()
+
+    mock_exit.assert_not_called()
+    assert arr.ready is False
+    assert arr.failure_kind == "definitive"
+    assert "API_KEY" in arr.setup_tip
+
+
+@pytest.mark.asyncio
+async def test_setup_non_english_ui_marks_definitive():
+    arr = ArrInstance(_make_settings(), "sonarr", "http://sonarr/", "test_key")
+
+    with patch(
+        "src.settings._instances.make_request",
+        new_callable=AsyncMock,
+        side_effect=_healthy_responses(ui_language=2),
+    ):
+        await arr.setup()
+
+    assert arr.ready is False
+    assert arr.failure_kind == "definitive"
+
+
+@pytest.mark.asyncio
+async def test_setup_recovers_on_retry():
+    arr = ArrInstance(_make_settings(), "sonarr", "http://sonarr/", "test_key")
+
+    with patch(
+        "src.settings._instances.make_request",
+        new_callable=AsyncMock,
+        side_effect=requests.exceptions.ReadTimeout("Read timed out."),
+    ):
+        assert await arr.setup() is False
+
+    with patch(
+        "src.settings._instances.make_request",
+        new_callable=AsyncMock,
+        side_effect=_healthy_responses(),
+    ):
+        assert await arr.setup() is True
+
+    assert arr.ready is True
+    assert arr.failure_kind is None
+    assert arr.last_error is None
+    assert arr.name == "MockSonarr"
+
+
+@pytest.mark.asyncio
+async def test_setup_same_error_logs_tip_block_once(caplog):
+    arr = ArrInstance(_make_settings(), "sonarr", "http://sonarr/", "test_key")
+
+    with patch(
+        "src.settings._instances.make_request",
+        new_callable=AsyncMock,
+        side_effect=requests.exceptions.ReadTimeout("Read timed out."),
+    ):
+        with caplog.at_level("ERROR"):
+            await arr.setup()
+            await arr.setup()
+
+    tip_blocks = [r for r in caplog.records if "❗️" in r.message]
+    assert len(tip_blocks) == 1
+
+
+@pytest.mark.asyncio
+async def test_setup_wrong_arr_type_and_old_version_still_pass():
+    arr = ArrInstance(_make_settings(), "sonarr", "http://sonarr/", "test_key")
+
+    with patch(
+        "src.settings._instances.make_request",
+        new_callable=AsyncMock,
+        side_effect=_healthy_responses(app_name="Radarr", app_version="0.0.1"),
+    ):
+        assert await arr.setup() is True
+
+    assert arr.ready is True

--- a/tests/settings/test_sabnzbd_clients.py
+++ b/tests/settings/test_sabnzbd_clients.py
@@ -130,3 +130,67 @@ class TestSabnzbdClients:
         clients = SabnzbdClients(config, settings)
         assert len(clients) == 0
         assert "Error parsing sabnzbd client config" in caplog.text
+
+
+class TestSabnzbdSetupDegradation:
+    @pytest.mark.asyncio
+    async def test_setup_reachability_timeout_marks_transient(self):
+        from unittest.mock import patch
+
+        import requests
+
+        settings = Mock()
+        settings.min_versions.sabnzbd = "4.0.0"
+        client = SabnzbdClient(
+            settings=settings, base_url="http://sabnzbd:8080", api_key="key"
+        )
+
+        with patch(
+            "src.settings._download_clients_sabnzbd.make_request",
+            new_callable=AsyncMock,
+            side_effect=requests.exceptions.ReadTimeout("Read timed out."),
+        ):
+            result = await client.setup()
+
+        assert result is False
+        assert client.ready is False
+        assert client.failure_kind == "transient"
+
+    @pytest.mark.asyncio
+    async def test_setup_old_version_marks_definitive(self):
+        settings = Mock()
+        settings.min_versions.sabnzbd = "4.0.0"
+        client = SabnzbdClient(
+            settings=settings, base_url="http://sabnzbd:8080", api_key="key"
+        )
+        client.check_sabnzbd_reachability = AsyncMock()
+        client.fetch_version = AsyncMock()
+        client.version = "3.0.0"
+
+        await client.setup()
+
+        assert client.ready is False
+        assert client.failure_kind == "definitive"
+
+
+class TestSabnzbdBadKey:
+    @pytest.mark.asyncio
+    async def test_setup_bad_api_key_marks_definitive(self):
+        from unittest.mock import MagicMock, patch
+
+        settings = Mock()
+        settings.min_versions.sabnzbd = "4.0.0"
+        client = SabnzbdClient(
+            settings=settings, base_url="http://sabnzbd:8080", api_key="bad"
+        )
+        resp = MagicMock()
+        resp.json = MagicMock(return_value={"error": "API Key Incorrect"})
+        with patch(
+            "src.settings._download_clients_sabnzbd.make_request",
+            new_callable=AsyncMock,
+            return_value=resp,
+        ):
+            await client.setup()
+
+        assert client.ready is False
+        assert client.failure_kind == "definitive"

--- a/tests/utils/test_startup.py
+++ b/tests/utils/test_startup.py
@@ -1,0 +1,114 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.utils.startup import _exit_if_all_failed_definitively, retry_degraded_instances
+
+
+def _unit(ready=False, failure_kind=None, arr_type=None, setup_result=False):
+    unit = MagicMock()
+    unit.ready = ready
+    unit.failure_kind = failure_kind
+    unit.name = "Unit"
+    unit.base_url = "http://unit"
+    unit.last_error = "some error"
+    unit.setup_tip = "💡 Tip: fix it"
+    unit.arr_type = arr_type
+    unit.setup = AsyncMock(return_value=setup_result)
+    return unit
+
+
+def _settings(instances=None, qbits=None, sabnzbds=None):
+    settings = MagicMock()
+    settings.instances = instances or []
+    settings.download_clients.qbittorrent = qbits or []
+    settings.download_clients.sabnzbd = sabnzbds or []
+    settings.jobs.detect_deletions.enabled = True
+    return settings
+
+
+def test_exit_when_all_units_failed_definitively():
+    settings = _settings(
+        instances=[_unit(failure_kind="definitive")],
+        qbits=[_unit(failure_kind="definitive")],
+    )
+
+    with patch("src.utils.startup.wait_and_exit") as mock_exit:
+        _exit_if_all_failed_definitively(settings)
+
+    mock_exit.assert_called_once()
+
+
+def test_no_exit_when_one_unit_failed_transiently():
+    settings = _settings(
+        instances=[_unit(failure_kind="definitive"), _unit(failure_kind="transient")],
+    )
+
+    with patch("src.utils.startup.wait_and_exit") as mock_exit:
+        _exit_if_all_failed_definitively(settings)
+
+    mock_exit.assert_not_called()
+
+
+def test_no_exit_when_one_unit_is_healthy():
+    settings = _settings(
+        instances=[_unit(ready=True), _unit(failure_kind="definitive")],
+    )
+
+    with patch("src.utils.startup.wait_and_exit") as mock_exit:
+        _exit_if_all_failed_definitively(settings)
+
+    mock_exit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_retry_skips_ready_and_definitive_units(caplog):
+    ready_unit = _unit(ready=True)
+    definitive_unit = _unit(failure_kind="definitive")
+    settings = _settings(instances=[ready_unit, definitive_unit])
+
+    with caplog.at_level("ERROR"):
+        await retry_degraded_instances(settings)
+
+    ready_unit.setup.assert_not_awaited()
+    definitive_unit.setup.assert_not_awaited()
+    assert any("configuration error" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_retry_rejoins_transient_arr_and_sets_up_watchers():
+    arr = _unit(failure_kind="transient", arr_type="sonarr", setup_result=True)
+    settings = _settings(instances=[arr])
+    watch_manager = MagicMock()
+    watch_manager.setup_for_arr = AsyncMock()
+
+    await retry_degraded_instances(settings, watch_manager)
+
+    arr.setup.assert_awaited_once()
+    watch_manager.setup_for_arr.assert_awaited_once_with(arr)
+
+
+@pytest.mark.asyncio
+async def test_retry_logs_warning_when_still_failing(caplog):
+    arr = _unit(failure_kind="transient", arr_type="sonarr", setup_result=False)
+    settings = _settings(instances=[arr])
+    watch_manager = MagicMock()
+    watch_manager.setup_for_arr = AsyncMock()
+
+    with caplog.at_level("WARNING"):
+        await retry_degraded_instances(settings, watch_manager)
+
+    arr.setup.assert_awaited_once()
+    watch_manager.setup_for_arr.assert_not_awaited()
+    assert any("will retry next cycle" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_retry_exits_when_everything_becomes_definitive():
+    """If the only units are definitively failed, the per-cycle retry exits."""
+    settings = _settings(instances=[_unit(failure_kind="definitive")])
+
+    with patch("src.utils.startup.wait_and_exit") as mock_exit:
+        await retry_degraded_instances(settings)
+
+    mock_exit.assert_called_once()


### PR DESCRIPTION
## Summary

Today, if any single instance (Sonarr/Radarr/qBittorrent/SABnzbd) fails its startup check, decluttarr calls `wait_and_exit()` and the whole container goes down — taking healthy instances with it, and on a slow or briefly-unreachable server causing a crash-loop where it never gets past startup. This makes startup degrade **per-instance** instead.

## Behavior

Each unit now records a readiness state at setup:

- **Transient** failures (timeout, connection refused, 5xx) degrade only that instance; setup is retried every cycle and it **rejoins automatically** once its server responds (including re-establishing its `detect_deletions` watchers).
- **Definitive** config errors (401/403, wrong qBittorrent username/password, bad SABnzbd API key, non-English UI, client version too old) degrade the instance with a per-cycle ERROR + tip; they are not retried, since they can't self-heal — and retrying a bad qBittorrent password would get the source IP banned by qBit's failed-login protection.
- The app exits only when **nothing** is configured, or when **every** configured unit has failed definitively — re-checked each cycle, not only at launch.

## Safety: degraded download clients fail closed

A degraded download client is skipped everywhere a job would call it. Critically, removal jobs **fail closed**: a download whose configured client is degraded is **left untouched** rather than deleted, because its protection status (protected tag, private/public tracker) can't be verified while the client is down. This prevents a misconfigured or unreachable qBittorrent from causing protected or private torrents to be removed. Downloads on healthy clients — and on clients not configured in decluttarr — are unaffected.

## Why

This complements #333: that made the *runtime* resilient to request errors; this extends the same resilience to *startup*, so a single slow or misconfigured instance no longer crash-loops the container — the exact pain reported in #317. It also fixes a latent bug where `main.py` handed the deletion watchers to a throwaway `WatcherManager`, so `terminate()` stopped an instance that owned no observers.

## Validation

- Full test suite passes (the 2 `tests/deletion_handler` failures are pre-existing Windows path-separator issues that reproduce identically on `dev`).
- New unit tests cover: transient-vs-definitive classification, per-cycle retry + automatic rejoin, the all-definitive exit (both at launch and post-launch), degraded-client skipping across the job paths, and the fail-closed removal guard (built on the real grouped-download shape so it can't drift).
- Verified on a live setup: a degraded download client degrades gracefully while the healthy Sonarr/Radarr instances keep running, no protected/private torrents are touched, the app stays up (no crash-loop), and the client rejoins on recovery.

## Notes

- No `Closes #…` — this is proactive hardening rather than a fix for a specific open report, though it is the startup half of the #317 / #333 resilience story.
- Out of scope (reasonable follow-up): the per-unit setup state machine is currently duplicated across the arr / qBittorrent / SABnzbd classes; consolidating it into a shared helper would be a clean future PR.
