### PR TITLE
Support qBittorrent 5.2 API key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,8 +288,9 @@ services:
       # --- Download Clients ---
       QBITTORRENT: >
         - base_url: "http://qbittorrent:8080"
-          # username: "$QBIT_USERNAME" # (optional -> if not provided, assuming not needed)
-          # password: "$QBIT_PASSWORD" # (optional -> if not provided, assuming not needed)
+          # api_key: "$QBIT_API_KEY" # (recommended -> requires qBittorrent 5.2.0+; takes precedence over username/password)
+          # username: "$QBIT_USERNAME" # (legacy -> for qBittorrent < 5.2; ignored if api_key is set)
+          # password: "$QBIT_PASSWORD" # (legacy -> for qBittorrent < 5.2; ignored if api_key is set)
           name: "qBittorrent 1" # (optional -> if not provided, assuming "qBittorrent". Must correspond with what is specified in your *arr as download client name)
         - base_url: "http://qbittorrent:8080"
           name: "qBittorrent 2" 
@@ -704,8 +705,9 @@ Supported download clients: **qBittorrent** and **SABnzbd**.
 -   Type: List of qbit instances
 -   Keys per instance
     - base_url: URL under which the qbit can be reached (mandatory)
-    - username: Optional - only needed if your qbit requires authentication (which you may not need if you have configured qbit in a way that it disables it for local connections)
-    - password: Optional - see above
+    - api_key: Recommended - qBittorrent API key (requires qBittorrent 5.2.0 or newer; generate it under Web UI settings). Authenticates without storing credentials, and takes precedence over username/password if both are set.
+    - username: Legacy - only for qBittorrent < 5.2, or if your qbit requires authentication (which you may not need if qbit disables it for local connections). Ignored when api_key is set.
+    - password: Legacy - see above
     - name: Optional. Needs to correspond with the name that you have set up in your Arr instance. Defaults to "qBittorrent"
 
 #### SABNZBD

--- a/config/config_example.yaml
+++ b/config/config_example.yaml
@@ -71,8 +71,9 @@ instances:
 download_clients:
   qbittorrent:
     - base_url: "http://qbittorrent:8080" # You can use decluttarr without qbit (not all features available, see readme).
-      # username: xxxx # (optional -> if not provided, assuming not needed)
-      # password: xxxx # (optional -> if not provided, assuming not needed)
+      # api_key: "qbt_xxxx" # (recommended -> requires qBittorrent 5.2.0+; generate under Web UI settings. Takes precedence over username/password.)
+      # username: xxxx # (legacy -> for qBittorrent < 5.2; ignored if api_key is set)
+      # password: xxxx # (legacy -> for qBittorrent < 5.2; ignored if api_key is set)
       # name: "qBittorrent" # (optional -> if not provided, assuming "qBittorrent". Must correspond with what is specified in your *arr as download client name)
       # timeout: 30 # (optional -> overrides general timeout for this instance)
   # sabnzbd:

--- a/src/settings/_download_clients_qbit.py
+++ b/src/settings/_download_clients_qbit.py
@@ -59,6 +59,7 @@ class QbitClient:
         password: str = None,
         name: str = None,
         timeout: int | None = None,
+        api_key: str = None,
     ):
         self.settings = settings
         self._timeout = timeout
@@ -72,12 +73,19 @@ class QbitClient:
         self.min_version = MinVersions.qbittorrent
         self.username = username
         self.password = password
+        # Treat an empty/whitespace api_key as unset so it falls back to password auth.
+        self.api_key = api_key.strip() if isinstance(api_key, str) else api_key
         self.name = name
         if not self.name:
             logger.verbose(
                 "No name provided for qbittorrent client, assuming 'qBitorrent'. If the name used in your *arr is different, please correct either the name in your *arr, or set the name in your config",
             )
             self.name = "qBittorrent"
+
+        if self.api_key and (username or password):
+            logger.info(
+                f"qBittorrent '{self.name}': both api_key and username/password provided; using api_key (credentials ignored).",
+            )
 
         self._remove_none_attributes()
 
@@ -94,8 +102,27 @@ class QbitClient:
             if getattr(self, attr) is None:
                 delattr(self, attr)
 
+    def _auth_kwargs(self) -> dict:
+        """Return the make_request auth kwargs for the configured mode.
+
+        Key mode (qBit >= 5.2): stateless 'Authorization: Bearer' header on every
+        request. Password mode (legacy): the session SID cookie from refresh_cookie().
+        Must stay a method (not cached) so password mode reads the freshly
+        refreshed self.cookie each cycle.
+        """
+        api_key = getattr(self, "api_key", None)
+        if api_key:
+            return {"headers": {"Authorization": f"Bearer {api_key}"}}
+        return {"cookies": getattr(self, "cookie", None)}
+
     async def refresh_cookie(self):
         """Refresh the qBittorrent session cookie."""
+        if getattr(self, "api_key", None):
+            # Key mode is stateless; qBit rejects /auth/login under API-key auth.
+            logger.debug(
+                "_download_clients_qBit.py/refresh_cookie: API-key mode, skipping login",
+            )
+            return
 
         def _connection_error():
             error = "Login failed."
@@ -155,7 +182,7 @@ class QbitClient:
             endpoint,
             self.settings,
             timeout=self.timeout,
-            cookies=self.cookie,
+            **self._auth_kwargs(),
         )
         self.version = response.text[1:]  # Remove the '_v' prefix
         logger.debug(
@@ -177,13 +204,38 @@ class QbitClient:
                 "[Tip!] Consider upgrading to qBittorrent v5.0.0 or newer to reduce network overhead.",
             )
 
+    def log_auth_version_guidance(self):
+        """Log authentication guidance once the qBittorrent version is known."""
+        qbit_version = version.parse(self.version)
+        api_key = getattr(self, "api_key", None)
+
+        if api_key and qbit_version < version.parse("5.2.0"):
+            logger.warning(
+                "qBittorrent %s does not support API-key authentication; API keys "
+                "require qBittorrent 5.2.0 or newer. The configured API key did not "
+                "authenticate this connection.",
+                self.version,
+            )
+        elif (
+            not api_key
+            and (getattr(self, "username", None) or getattr(self, "password", None))
+            and qbit_version >= version.parse("5.2.0")
+        ):
+            logger.info(
+                "[Tip!] qBittorrent %s supports API-key authentication. Consider "
+                "replacing username/password with api_key.",
+                self.version,
+            )
+
     async def create_tag(self, tag: str):
         """Ensure a tag exists in qBittorrent; create it if it doesn't."""
         logger.debug(
             "_download_clients_qBit.py/create_tag: Checking if tag '{tag}' exists (and creating it if not)",
         )
         url = f"{self.api_url}/torrents/tags"
-        response = await make_request("get", url, self.settings, timeout=self.timeout, cookies=self.cookie)
+        response = await make_request(
+            "get", url, self.settings, timeout=self.timeout, **self._auth_kwargs()
+        )
         current_tags = response.json()
 
         if tag not in current_tags:
@@ -195,7 +247,7 @@ class QbitClient:
                 self.settings,
                 timeout=self.timeout,
                 data=data,
-                cookies=self.cookie,
+                **self._auth_kwargs(),
             )
 
     async def create_required_tags(self):
@@ -220,7 +272,7 @@ class QbitClient:
                 endpoint,
                 self.settings,
                 timeout=self.timeout,
-                cookies=self.cookie,
+                **self._auth_kwargs(),
             )
             qbit_settings = response.json()
 
@@ -235,7 +287,7 @@ class QbitClient:
                     self.settings,
                     timeout=self.timeout,
                     data=data,
-                    cookies=self.cookie,
+                    **self._auth_kwargs(),
                 )
 
     async def check_qbit_reachability(self):
@@ -244,24 +296,44 @@ class QbitClient:
             logger.debug(
                 "_download_clients_qBit.py/check_qbit_reachability: Checking if qbit is reachable",
             )
-            endpoint = f"{self.api_url}/auth/login"
-            data = {
-                "username": getattr(self, "username", ""),
-                "password": getattr(self, "password", ""),
-            }
-            headers = {"content-type": "application/x-www-form-urlencoded"}
-            response = await make_request(
-                "post",
-                endpoint,
-                self.settings,
-                timeout=self.timeout,
-                data=data,
-                headers=headers,
-                log_error=False,
-                ignore_test_run=True,
-            )
+            if getattr(self, "api_key", None):
+                # Key mode: qBit rejects /auth/login, so probe a normal authed
+                # endpoint with the Bearer header instead.
+                await make_request(
+                    "get",
+                    f"{self.api_url}/app/version",
+                    self.settings,
+                    timeout=self.timeout,
+                    log_error=False,
+                    ignore_test_run=True,
+                    **self._auth_kwargs(),
+                )
+                response = None  # key mode: no login body to inspect below
+            else:
+                endpoint = f"{self.api_url}/auth/login"
+                data = {
+                    "username": getattr(self, "username", ""),
+                    "password": getattr(self, "password", ""),
+                }
+                headers = {"content-type": "application/x-www-form-urlencoded"}
+                response = await make_request(
+                    "post",
+                    endpoint,
+                    self.settings,
+                    timeout=self.timeout,
+                    data=data,
+                    headers=headers,
+                    log_error=False,
+                    ignore_test_run=True,
+                )
         except Exception as e:  # noqa: BLE001
-            tip = "💡 Tip: Did you specify the URL (and username/password if required) correctly?"
+            if getattr(self, "api_key", None):
+                tip = (
+                    "💡 Tip: Is the qBittorrent API key correct, and is your qBittorrent "
+                    "at least v5.2.0? API-key auth requires qBit 5.2+ (WebAPI 2.14.1+)."
+                )
+            else:
+                tip = "💡 Tip: Did you specify the URL (and username/password if required) correctly?"
             if str(e) != self.last_error:  # Only report new failure modes in full
                 logger.error(f"-- | qBittorrent\n❗️ {e}\n{tip}\n")
             raise QbitError(e, tip=tip) from e
@@ -289,14 +361,15 @@ class QbitClient:
                         self.api_url + "/sync/maindata",
                         self.settings,
                         timeout=self.timeout,
-                        cookies=self.cookie,
+                        **self._auth_kwargs(),
                     )
                 ).json()
             )["server_state"]["connection_status"]
-        except Exception:
+        except Exception as e:
             logger.warning(
-                ">>> %s: Failed to reach /sync/maindata. Treating as disconnected.",
+                ">>> %s: Failed to reach /sync/maindata (%s). Treating as disconnected.",
                 self.name,
+                e,
             )
             return False
         if qbit_connection_status == "disconnected":
@@ -314,6 +387,7 @@ class QbitClient:
             # Fetch version and validate it
             await self.fetch_version()
             await self.validate_version()
+            self.log_auth_version_guidance()
 
             await self.create_required_tags()
             await self.set_unwanted_folder()
@@ -411,7 +485,7 @@ class QbitClient:
             self.settings,
             timeout=self.timeout,
             data=data,
-            cookies=self.cookie,
+            **self._auth_kwargs(),
         )
 
     async def fetch_download_progress(self, download_id):
@@ -435,7 +509,7 @@ class QbitClient:
             settings=self.settings,
             timeout=self.timeout,
             params=None,  # Retrieve all torrents
-            cookies=self.cookie,
+            **self._auth_kwargs(),
         )
 
         all_items = response.json()
@@ -458,7 +532,7 @@ class QbitClient:
             self.settings,
             timeout=self.timeout,
             params=params,
-            cookies=self.cookie,
+            **self._auth_kwargs(),
         )
         return response.json()
 
@@ -471,7 +545,7 @@ class QbitClient:
             settings=self.settings,
             timeout=self.timeout,
             params={"hash": download_id.lower()},
-            cookies=self.cookie,
+            **self._auth_kwargs(),
         )
         return response.json()
 
@@ -490,7 +564,7 @@ class QbitClient:
             self.settings,
             timeout=self.timeout,
             data=data,
-            cookies=self.cookie,
+            **self._auth_kwargs(),
         )
 
     async def set_bandwidth_usage(self):
@@ -501,7 +575,7 @@ class QbitClient:
             endpoint=self.api_url + "/transfer/info",
             settings=self.settings,
             timeout=self.timeout,
-            cookies=self.cookie,
+            **self._auth_kwargs(),
         )
         records = extract_json_from_response(response)
         limit = records["dl_rate_limit"]
@@ -539,5 +613,5 @@ class QbitClient:
             self.settings,
             timeout=self.timeout,
             data=data,
-            cookies=self.cookie,
+            **self._auth_kwargs(),
         )

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -26,7 +26,14 @@ def sanitize_kwargs(data):
         for key, value in data.items():
             if (
                 key.lower()
-                in {"username", "password", "x-api-key", "apikey", "cookies"}
+                in {
+                    "username",
+                    "password",
+                    "x-api-key",
+                    "apikey",
+                    "cookies",
+                    "authorization",
+                }
                 and value
             ):
                 redacted[key] = "[**redacted**]"

--- a/tests/settings/test_download_clients_qbit.py
+++ b/tests/settings/test_download_clients_qbit.py
@@ -111,3 +111,169 @@ async def test_setup_bad_password_marks_definitive():
 
     assert client.ready is False
     assert client.failure_kind == "definitive"
+
+
+# --- API-key (qBit 5.2+) authentication ---
+
+VALID_KEY = "qbt_" + "a" * 28
+
+
+def test_auth_kwargs_key_mode_uses_bearer_header():
+    client = QbitClient(MagicMock(), base_url="http://qbit:8080", api_key=VALID_KEY)
+    assert client._auth_kwargs() == {
+        "headers": {"Authorization": f"Bearer {VALID_KEY}"}
+    }
+
+
+def test_auth_kwargs_password_mode_uses_cookie():
+    client = QbitClient(
+        MagicMock(), base_url="http://qbit:8080", username="u", password="p"
+    )
+    client.cookie = {"SID": "abc"}
+    assert client._auth_kwargs() == {"cookies": {"SID": "abc"}}
+
+
+def test_empty_api_key_falls_back_to_password_mode():
+    client = QbitClient(
+        MagicMock(),
+        base_url="http://qbit:8080",
+        api_key="   ",
+        username="u",
+        password="p",
+    )
+    client.cookie = {"SID": "abc"}
+    # Whitespace-only key is treated as unset.
+    assert client._auth_kwargs() == {"cookies": {"SID": "abc"}}
+
+
+def test_both_provided_key_wins_and_logs(caplog):
+    with caplog.at_level("INFO"):
+        client = QbitClient(
+            MagicMock(),
+            base_url="http://qbit:8080",
+            api_key=VALID_KEY,
+            username="u",
+            password="p",
+        )
+    assert "Authorization" in client._auth_kwargs()["headers"]
+    assert any("using api_key" in r.message for r in caplog.records)
+
+
+def test_old_version_with_api_key_warns_without_raising(caplog):
+    client = QbitClient(MagicMock(), base_url="http://qbit:8080", api_key=VALID_KEY)
+    client.version = "5.1.2"
+
+    with caplog.at_level("WARNING"):
+        client.log_auth_version_guidance()
+
+    assert "does not support API-key authentication" in caplog.text
+    assert "API key did not authenticate this connection" in caplog.text
+
+
+def test_supported_version_with_password_recommends_api_key(caplog):
+    client = QbitClient(
+        MagicMock(), base_url="http://qbit:8080", username="u", password="p"
+    )
+    client.version = "5.2.0"
+
+    with caplog.at_level("INFO"):
+        client.log_auth_version_guidance()
+
+    assert "supports API-key authentication" in caplog.text
+    assert "replacing username/password with api_key" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("version_value", "credentials"),
+    [
+        ("5.2.0", {"api_key": VALID_KEY}),
+        ("5.1.2", {"username": "u", "password": "p"}),
+    ],
+)
+def test_auth_version_guidance_omits_irrelevant_advice(
+    caplog, version_value, credentials
+):
+    client = QbitClient(MagicMock(), base_url="http://qbit:8080", **credentials)
+    client.version = version_value
+
+    with caplog.at_level("INFO"):
+        client.log_auth_version_guidance()
+
+    assert "API-key authentication" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_fetch_version_key_mode_sends_bearer_not_cookie():
+    client = QbitClient(MagicMock(), base_url="http://qbit:8080", api_key=VALID_KEY)
+
+    with patch(
+        "src.settings._download_clients_qbit.make_request", new_callable=AsyncMock
+    ) as mock_req:
+        mock_req.return_value = MagicMock(text="_v5.2.0")
+        await client.fetch_version()
+
+    kwargs = mock_req.call_args.kwargs
+    assert kwargs["headers"] == {"Authorization": f"Bearer {VALID_KEY}"}
+    assert "cookies" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_refresh_cookie_noop_in_key_mode():
+    client = QbitClient(MagicMock(), base_url="http://qbit:8080", api_key=VALID_KEY)
+
+    with patch(
+        "src.settings._download_clients_qbit.make_request", new_callable=AsyncMock
+    ) as mock_req:
+        await client.refresh_cookie()
+
+    mock_req.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reachability_key_mode_probes_app_version():
+    client = QbitClient(MagicMock(), base_url="http://qbit:8080", api_key=VALID_KEY)
+
+    with patch(
+        "src.settings._download_clients_qbit.make_request", new_callable=AsyncMock
+    ) as mock_req:
+        await client.check_qbit_reachability()
+
+    method, endpoint = mock_req.call_args.args[0], mock_req.call_args.args[1]
+    assert method == "get"
+    assert endpoint.endswith("/app/version")
+
+
+@pytest.mark.asyncio
+async def test_reachability_password_mode_still_posts_login():
+    client = QbitClient(
+        MagicMock(), base_url="http://qbit:8080", username="u", password="p"
+    )
+
+    with patch(
+        "src.settings._download_clients_qbit.make_request", new_callable=AsyncMock
+    ) as mock_req:
+        await client.check_qbit_reachability()
+
+    method, endpoint = mock_req.call_args.args[0], mock_req.call_args.args[1]
+    assert method == "post"
+    assert endpoint.endswith("/auth/login")
+
+
+@pytest.mark.asyncio
+async def test_setup_bad_key_403_marks_definitive_with_tip():
+    http_error = requests.exceptions.HTTPError("403 Forbidden")
+    http_error.response = MagicMock(status_code=403)
+
+    client = QbitClient(MagicMock(), base_url="http://qbit:8080", api_key=VALID_KEY)
+
+    with patch(
+        "src.settings._download_clients_qbit.make_request",
+        new_callable=AsyncMock,
+        side_effect=http_error,
+    ):
+        result = await client.setup()
+
+    assert result is False
+    assert client.ready is False
+    assert client.failure_kind == "definitive"
+    assert "5.2" in client.setup_tip

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -45,3 +45,14 @@ async def test_make_request_allows_explicit_timeout_override():
 
     assert to_thread.await_count == 1
     assert to_thread.await_args.kwargs["timeout"] == 7
+
+
+def test_sanitize_kwargs_redacts_authorization_header():
+    """The Bearer token must never survive into logs."""
+    from src.utils.common import sanitize_kwargs
+
+    data = {"headers": {"Authorization": "Bearer qbt_supersecrettoken"}}
+    result = sanitize_kwargs(data)
+
+    assert result["headers"]["Authorization"] == "[**redacted**]"
+    assert "qbt_supersecrettoken" not in str(result)


### PR DESCRIPTION
## Summary
Adds support for qBittorrent 5.2's stateless API key auth (`Authorization: Bearer <key>`) and makes it the recommended way to connect. Username and password stay as a legacy fallback for qBit older than 5.2.

Closes #353.

## Behavior
- Set `api_key` on a qbittorrent client and decluttarr sends `Authorization: Bearer <key>` on every request. No login call, no session cookie.
- If both `api_key` and username/password are set, the key wins (matching qBit's own precedence) and a one time info log notes the credentials are ignored.
- Requires qBit 5.2.0 or newer. A bad key or a too old server both return 403, which degrades that instance with a tip covering both causes rather than crash looping the container (builds on #366).

## Security
- `Authorization` is added to the log redaction set, so the Bearer token is never written to debug logs.

## Also
- `check_connected` now includes the underlying error in its warning, so a key revoked at runtime surfaces the auth failure instead of a generic "disconnected" line.

## Testing
- New tests cover key mode vs password mode request shaping, the reachability probe, precedence when both are set, 403 degradation with the tip, and token redaction.
- Full suite green (the 2 Windows path failures are pre existing on dev and unrelated).
- Validated on live hardware: a correct key connects and runs cleanly; a wrong key degrades gracefully with the tip, the app stays up, and no protected or private torrents are touched.
