### PR TITLE
[NEEDS CODE REVIEWER] fix: Skip stale queue items during unmonitored checks

### DIFF
--- a/src/jobs/remove_unmonitored.py
+++ b/src/jobs/remove_unmonitored.py
@@ -1,4 +1,7 @@
+import requests
+
 from src.jobs.removal_job import RemovalJob
+from src.utils.log_setup import logger
 
 
 class RemoveUnmonitored(RemovalJob):
@@ -10,7 +13,24 @@ class RemoveUnmonitored(RemovalJob):
         monitored_download_ids = []
         for item in self.queue:
             detail_item_id = item["detail_item_id"]
-            if detail_item_id is None or await self.arr.is_monitored(detail_item_id):
+            try:
+                is_monitored = detail_item_id is None or await self.arr.is_monitored(
+                    detail_item_id
+                )
+            except requests.exceptions.HTTPError as err:
+                response = getattr(err, "response", None)
+                if response is None or response.status_code != 404:  # noqa: PLR2004
+                    raise
+                logger.warning(
+                    "Skipping stale queue item %s: %s %s no longer exists on %s.",
+                    item.get("downloadId"),
+                    self.arr.detail_item_key,
+                    detail_item_id,
+                    self.arr.name,
+                )
+                is_monitored = True
+
+            if is_monitored:
                 # When queue item has been matched to artist (for instance in lidarr) but not yet to the detail (eg. album), then detail key is logically missing.
                 # Thus we can't check if the item is monitored yet
                 monitored_download_ids.append(item["downloadId"])

--- a/tests/jobs/test_remove_unmonitored.py
+++ b/tests/jobs/test_remove_unmonitored.py
@@ -1,6 +1,8 @@
-from unittest.mock import AsyncMock
+import logging
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import requests
 
 from src.jobs.remove_unmonitored import RemoveUnmonitored
 from tests.jobs.utils import shared_fix_affected_items, shared_test_affected_items
@@ -73,3 +75,37 @@ async def test_find_affected_items(queue_data, monitored_ids, expected_download_
     removal_job.arr.is_monitored = AsyncMock(side_effect=lambda id_: monitored_ids[id_])
     # Act and Assert
     await shared_test_affected_items(removal_job, expected_download_ids)
+
+
+@pytest.mark.asyncio
+async def test_stale_queue_item_is_skipped_and_processing_continues(caplog):
+    queue_data = [
+        {"downloadId": "stale", "detail_item_id": 101},
+        {"downloadId": "unmonitored", "detail_item_id": 102},
+    ]
+    removal_job = shared_fix_affected_items(RemoveUnmonitored, queue_data)
+    removal_job.arr.detail_item_key = "book"
+    removal_job.arr.name = "Readarr"
+
+    not_found = requests.exceptions.HTTPError("404 Not Found")
+    not_found.response = MagicMock(status_code=404)
+    removal_job.arr.is_monitored = AsyncMock(side_effect=[not_found, False])
+
+    with caplog.at_level(logging.WARNING, logger="src.utils.log_setup"):
+        await shared_test_affected_items(removal_job, ["unmonitored"])
+
+    removal_job.arr.is_monitored.assert_awaited()
+    assert "Skipping stale queue item stale" in caplog.text
+    assert "book 101 no longer exists on Readarr" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_non_404_monitoring_error_is_raised():
+    queue_data = [{"downloadId": "failed", "detail_item_id": 101}]
+    removal_job = shared_fix_affected_items(RemoveUnmonitored, queue_data)
+    server_error = requests.exceptions.HTTPError("500 Server Error")
+    server_error.response = MagicMock(status_code=500)
+    removal_job.arr.is_monitored = AsyncMock(side_effect=server_error)
+
+    with pytest.raises(requests.exceptions.HTTPError, match="500 Server Error"):
+        await removal_job._find_affected_items()  # pylint: disable=protected-access


### PR DESCRIPTION
## Summary

Prevents a stale queue item from crashing Decluttarr when its referenced detail item no longer exists in the configured Arr instance.

- Treats a `404` returned while checking monitored status as a stale queue record
- Logs which download and detail item were skipped
- Continues processing the remaining queue
- Re-raises non-404 HTTP errors instead of hiding unrelated failures
- Preserves the existing shared-download behavior by treating the stale record as non-removable

Closes #341

## Test plan

- [x] Stale queue item returning `404` is skipped
- [x] Remaining unmonitored items are still detected
- [x] Warning identifies the stale download and detail item
- [x] Non-404 HTTP errors are re-raised
- [x] `pytest tests/jobs/test_remove_unmonitored.py tests/settings/test_instances.py tests/jobs/test_job_manager.py`
- [x] Black and isort checks
