### PR TITLE
[NEEDS CODE REVIEWER] fix: Clarify malformed environment YAML errors

### DIFF
--- a/src/settings/_user_config.py
+++ b/src/settings/_user_config.py
@@ -93,7 +93,11 @@ def _load_from_env() -> dict:
                 parsed_value = _lowercase(parsed_value)
             except yaml.YAMLError as e:
                 logger.error(
-                    f"Failed to parse environment variable {key} as YAML:\n{e}",
+                    "Could not parse %s as YAML. Check for smart quotes or "
+                    "incorrect indentation. Configuration from this variable "
+                    "was ignored.\n%s",
+                    key,
+                    e,
                 )
                 parsed_value = {}
             section_config[key.lower()] = parsed_value

--- a/tests/settings/test_user_config_from_env.py
+++ b/tests/settings/test_user_config_from_env.py
@@ -1,5 +1,6 @@
 """Test loading the user configuration from environment variables."""
 
+import logging
 import os
 import textwrap
 from unittest.mock import patch
@@ -137,3 +138,20 @@ def test_env_loading_parametrized(
         assert value == expected
     else:
         assert value == expected
+
+
+def test_invalid_download_client_yaml_logs_actionable_error(caplog):
+    malformed_qbit_yaml = '- base_url: "http://qbittorrent:8080'
+
+    with (
+        patch.dict(os.environ, {"QBITTORRENT": malformed_qbit_yaml}, clear=True),
+        caplog.at_level(logging.ERROR, logger="src.utils.log_setup"),
+    ):
+        config = _load_from_env()
+
+    assert config["download_clients"]["qbittorrent"] == {}
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "Could not parse QBITTORRENT as YAML" in message
+    assert "smart quotes or incorrect indentation" in message
+    assert "Configuration from this variable was ignored" in message


### PR DESCRIPTION
## Summary

Makes YAML parsing failures from configuration environment variables easier to diagnose.

The error now:

- Names the environment variable that could not be parsed
- Suggests checking for smart quotes or incorrect indentation
- Clearly states that configuration from the malformed variable was ignored
- Remains a single startup error rather than failing the entire application

Adds regression coverage for malformed `QBITTORRENT` YAML and verifies that the resulting message is actionable.

Closes #363

## Test plan

- [x] Malformed download-client YAML falls back safely
- [x] Exactly one actionable parsing error is logged
- [x] Error identifies the offending environment variable
- [x] Error explains that its configuration was ignored
- [x] `pytest tests/settings/test_user_config_from_env.py`
- [x] Black and isort checks
