### PR TITLE
[NEEDS CODE REVIEWER] feat: Add Sportarr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Looking to **upgrade from V1 to V2**? Look [here](#upgrading-from-v1-to-v2)
 
 Decluttarr is a helper tool that works with the *arr-application suite, and automates the clean-up for their download queues, keeping them free of stalled / redundant downloads. 
 
-It supports [Radarr](https://github.com/Radarr/Radarr/), [Sonarr](https://github.com/Sonarr/Sonarr/), [Readarr](https://github.com/Readarr/Readarr/), [Lidarr](https://github.com/Lidarr/Lidarr/), and [Whisparr](https://github.com/Whisparr/Whisparr/).
+It supports [Radarr](https://github.com/Radarr/Radarr/), [Sonarr](https://github.com/Sonarr/Sonarr/), [Sportarr](https://github.com/Sportarr/Sportarr/), [Readarr](https://github.com/Readarr/Readarr/), [Lidarr](https://github.com/Lidarr/Lidarr/), and [Whisparr](https://github.com/Whisparr/Whisparr/).
 
 Feature overview:
 
@@ -275,6 +275,10 @@ services:
           api_key: "$SONARR_API_KEY"
         - base_url: "http://sonarr2:8989"
           api_key: "$SONARR_API_KEY"
+
+      # SPORTARR: >
+      #   - base_url: "http://sportarr:1867"
+      #     api_key: "$SPORTARR_API_KEY"
 
       # RADARR: >
       #   - base_url: "http://radarr:7878"

--- a/config/config_example.yaml
+++ b/config/config_example.yaml
@@ -55,6 +55,9 @@ instances:
     - base_url: "http://sonarr:8989"
       api_key: "xxxx"
       # timeout: 30 # Optional: Overrides general timeout for this instance.
+  # sportarr:
+  #   - base_url: "http://sportarr:1867"
+  #     api_key: "xxxx"
   radarr:
     - base_url: "http://radarr:7878"
       api_key: "xxxx"

--- a/src/deletion_handler/deletion_handler.py
+++ b/src/deletion_handler/deletion_handler.py
@@ -122,6 +122,7 @@ class WatcherManager:
         folders_to_watch = []
         if arr.arr_type not in (
             "sonarr",
+            "sportarr",
             "radarr",
         ):  # only working for sonarr / radarr for now
             return folders_to_watch

--- a/src/jobs/search_handler.py
+++ b/src/jobs/search_handler.py
@@ -122,7 +122,7 @@ class SearchHandler:
                 title = item.get("title", "Unknown")
                 logger.verbose(f"- {title}")
 
-            elif self.arr.arr_type == "sonarr":
+            elif self.arr.arr_type in ("sonarr", "sportarr"):
                 logger.debug(
                     "search_handler.py/_log_items: Getting series information for better display in output"
                 )

--- a/src/settings/_constants.py
+++ b/src/settings/_constants.py
@@ -22,6 +22,7 @@ class Paths:
 class ApiEndpoints:
     radarr = "/api/v3"
     sonarr = "/api/v3"
+    sportarr = "/api/v3"
     lidarr = "/api/v1"
     readarr = "/api/v1"
     whisparr = "/api/v3"
@@ -31,6 +32,7 @@ class ApiEndpoints:
 class MinVersions:
     radarr = "5.10.3.9171"
     sonarr = "4.0.9.2332"
+    sportarr = "4.0.0.0"
     lidarr = "2.11.1.4621"
     readarr = "0.4.15.2787"
     whisparr = "2.0.0.548"
@@ -41,6 +43,7 @@ class MinVersions:
 class FullQueueParameter:
     radarr = "includeUnknownMovieItems"
     sonarr = "includeUnknownSeriesItems"
+    sportarr = "includeUnknownSeriesItems"
     lidarr = "includeUnknownArtistItems"
     readarr = "includeUnknownAuthorItems"
     whisparr = "includeUnknownSeriesItems"
@@ -49,6 +52,7 @@ class FullQueueParameter:
 class DetailItemKey:
     radarr = "movie"
     sonarr = "episode"
+    sportarr = "episode"
     lidarr = "album"
     readarr = "book"
     whisparr = "episode"
@@ -57,6 +61,7 @@ class DetailItemKey:
 class DetailItemSearchCommand:
     radarr = "MoviesSearch"
     sonarr = "EpisodeSearch"
+    sportarr = "EpisodeSearch"
     lidarr = "AlbumSearch"
     readarr = "BookSearch"
     whisparr = None
@@ -65,8 +70,10 @@ class DetailItemSearchCommand:
 class RefreshItemKey:
     radarr = "movie"
     sonarr = "series"
+    sportarr = "series"
 
 
 class RefreshItemCommand:
     radarr = "RefreshMovie"
     sonarr = "RefreshSeries"
+    sportarr = "RefreshSeries"

--- a/src/settings/_instances.py
+++ b/src/settings/_instances.py
@@ -91,7 +91,7 @@ class ArrInstances(list):
         }
 
         outputs = []
-        for arr_type in ["sonarr", "radarr", "readarr", "lidarr", "whisparr"]:
+        for arr_type in ["sonarr", "sportarr", "radarr", "readarr", "lidarr", "whisparr"]:
             arrs = self.get_by_arr_type(arr_type)
             if arrs:
                 output = get_config_as_yaml(
@@ -174,7 +174,7 @@ class ArrInstance:
         self.detail_item_id_key = self.detail_item_key + "Id"
         self.detail_item_ids_key = self.detail_item_key + "Ids"
         self.detail_item_search_command = getattr(DetailItemSearchCommand, arr_type)
-        if self.arr_type in ("radarr", "sonarr"):
+        if self.arr_type in ("radarr", "sonarr", "sportarr"):
             self.refresh_item_key = getattr(RefreshItemKey, arr_type)
             self.refresh_item_id_key = self.refresh_item_key + "Id"
             self.refresh_item_command = getattr(RefreshItemCommand, arr_type)

--- a/src/settings/_instances.py
+++ b/src/settings/_instances.py
@@ -219,6 +219,13 @@ class ArrInstance:
     def _check_arr_type(self, status):
         """Check if the ARR instance is of the correct type."""
         actual_arr_type = status["appName"]
+        if self.arr_type == "sportarr":
+            # Sportarr's Sonarr-compatible API reports appName "Sonarr" (other
+            # consumers validate on that), so its identity marker is the extra
+            # sportarrVersion field a real Sonarr never sends.
+            if "sportarrVersion" in status:
+                return
+            actual_arr_type = "Sonarr"
         if actual_arr_type.lower() != self.arr_type:
             logger.error("!! %s Error: !!", self.name)
             logger.error(

--- a/src/settings/_user_config.py
+++ b/src/settings/_user_config.py
@@ -41,7 +41,7 @@ CONFIG_MAPPING = {
         "SEARCH_UNMET_CUTOFF",
         "SEARCH_MISSING",
     ],
-    "instances": ["SONARR", "RADARR", "READARR", "LIDARR", "WHISPARR"],
+    "instances": ["SONARR", "SPORTARR", "RADARR", "READARR", "LIDARR", "WHISPARR"],
     "download_clients": ["QBITTORRENT"],
 }
 

--- a/src/utils/startup.py
+++ b/src/utils/startup.py
@@ -133,7 +133,7 @@ async def retry_degraded_instances(settings, watch_manager=None):
             )
             if (
                 watch_manager
-                and getattr(unit, "arr_type", None) in ("sonarr", "radarr")
+                and getattr(unit, "arr_type", None) in ("sonarr", "sportarr", "radarr")
                 and settings.jobs.detect_deletions.enabled
             ):
                 await watch_manager.setup_for_arr(unit)


### PR DESCRIPTION

Adds [Sportarr](https://github.com/Sportarr/Sportarr), a sports event
manager with a Sonarr-v3-compatible API, as a supported instance type.
It mirrors the sonarr constants and joins sonarr in the per-type
conditionals (instances, refresh, deletion watchers, search logging,
startup rejoin), plus README/config-example blocks.

I maintain Sportarr; its API serves the endpoints decluttarr drives:
queue listing and DELETE queue with removal/blocklist semantics
(added in Sportarr for this integration), refresh and search commands.

Tested: full pytest suite passes (292); ruff clean on touched files
(pre-existing findings untouched); verified live against a real Sportarr instance with a genuinely stalled torrent in qBittorrent: the instance check identifies Sportarr, remove_stalled struck and removed the item, the queue row was deleted, the release was blocklisted, and the torrent was removed from the client. Requires Sportarr v4.1.0 or newer.

