### PR TITLE
fix(search): sort wanted list ascending so backlog isn't starved

### DIFF
--- a/src/utils/wanted_manager.py
+++ b/src/utils/wanted_manager.py
@@ -27,7 +27,16 @@ class WantedManager:
             return []
 
         sort_key = f"{self.arr.detail_item_key}s.lastSearchTime"
-        params = {"page": "1", "pageSize": total_records_count, "sortKey": sort_key}
+        # sortDirection must be explicit: the *arr API defaults to descending for
+        # lastSearchTime, which puts most-recently-searched items first and never-searched
+        # items (null lastSearchTime) last. That starves the backlog, re-searching the same
+        # top N forever. Ascending puts least-/never-searched items first, as intended (#376).
+        params = {
+            "page": "1",
+            "pageSize": total_records_count,
+            "sortKey": sort_key,
+            "sortDirection": "ascending",
+        }
 
         records = await self.fetch_wanted_field(
             missing_or_cutoff, params=params, key="records"

--- a/tests/utils/test_wanted_manager.py
+++ b/tests/utils/test_wanted_manager.py
@@ -1,0 +1,39 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from src.utils.wanted_manager import WantedManager
+
+
+# ---------- Fixtures ----------
+@pytest.fixture(name="mock_wanted_manager")
+def fixture_mock_wanted_manager():
+    mock_arr = Mock()
+    mock_arr.detail_item_key = "episode"
+    mock_settings = Mock()
+    return WantedManager(arr=mock_arr, settings=mock_settings)
+
+
+# ---------- Tests ----------
+@pytest.mark.asyncio
+async def test_get_arr_records_empty_returns_early(mock_wanted_manager):
+    mock_wanted_manager.fetch_wanted_field = AsyncMock()
+    result = await mock_wanted_manager._get_arr_records("missing", 0)  # pylint: disable=W0212
+    assert result == []
+    mock_wanted_manager.fetch_wanted_field.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_arr_records_sorts_ascending(mock_wanted_manager):
+    # Regression test for #376: without an explicit ascending sortDirection the
+    # *arr API returns most-recently-searched items first, re-searching the same
+    # top N forever while never-searched items are starved.
+    mock_wanted_manager.fetch_wanted_field = AsyncMock(return_value=[{"id": 1}])
+
+    await mock_wanted_manager._get_arr_records("missing", 42)  # pylint: disable=W0212
+
+    _, kwargs = mock_wanted_manager.fetch_wanted_field.call_args
+    params = kwargs["params"]
+    assert params["sortKey"] == "episodes.lastSearchTime"
+    assert params["sortDirection"] == "ascending"
+    assert params["pageSize"] == 42


### PR DESCRIPTION
## Summary

Fixes #376.

`search_missing` (and `search_unmet_cutoff`) could permanently re-search the same top `MAX_CONCURRENT_SEARCHES` items while items that had never been searched were never reached — logging a normal success line every cycle, so it looked healthy.

## Root cause

`src/utils/wanted_manager.py::_get_arr_records` sent `sortKey` but no `sortDirection`:

```python
params = {"page": "1", "pageSize": total_records_count, "sortKey": sort_key}
```

For `lastSearchTime` the *arr API defaults to **descending**, so the list comes back most-recently-searched first and never-searched items (`lastSearchTime: null`) last. `search_handler.py::_filter_wanted_items` then slices from the top (`items[:max_concurrent_searches]`), so it re-selects the items it just searched. With `min_days_between_searches=0` the recent-search guard (`_filter_recent_searches`) never evicts anything either, turning this into total starvation of the backlog.

Confirmed against a live Sonarr in the issue thread: same endpoint and `sortKey`, only `sortDirection` varies — `ascending` yields the never-searched-first order the code intends.

## Fix

Request the direction explicitly:

```python
params = {
    "page": "1",
    "pageSize": total_records_count,
    "sortKey": sort_key,
    "sortDirection": "ascending",
}
```

Least-/never-searched items lead, which is what the job intends, and it is correct at any `min_days_between_searches` including `0`.

## Tests

Adds `tests/utils/test_wanted_manager.py`: a regression test asserting `sortDirection=ascending` in the request params, plus the empty-records early-return path. Full suite passes locally (`pytest`).

Credit to the original reporter for the diagnosis and live-Sonarr verification in #376.

Generated with [Claude Code](https://claude.com/claude-code)
