### PR TITLE
Add `remove_from_queue` tracker handling mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,8 +439,9 @@ Configures the general behavior of the application (across all features)
     -   "remove" means that torrents are removed (default behavior)
     -   "skip" means they are disregarded (which some users might find handy to protect their private trackers prematurely, i.e., before their seed targets are met)
     -   "obsolete_tag" means that rather than being removed, the torrents are tagged. This allows other applications (such as [qbit_manage](https://github.com/StuffAnThings/qbit_manage) to monitor them and remove them once seed targets are fulfilled)
+    -   "remove_from_queue" behaves like "remove" on the *arr side (the queue entry is cleared, and blocklisted if the job blocklists), but leaves the torrent untouched in the download client. Use this when the torrent still carries a hit-and-run obligation you must honour: the *arr stops waiting on a download that will never import and is free to grab an alternative, while seeding continues and another application (such as [qbit_manage](https://github.com/StuffAnThings/qbit_manage)) retires the torrent on the tracker's terms. Unlike "obsolete_tag" this clears the queue entry immediately rather than waiting for the torrent to disappear
 -   Type: String
--   Permissible Values: remove, skip, obsolete_tag
+-   Permissible Values: remove, remove_from_queue, skip, obsolete_tag
 -   Is Mandatory: No (Defaults to remove)
 
 

--- a/config/config_example.yaml
+++ b/config/config_example.yaml
@@ -6,8 +6,8 @@ general:
   # ignored_download_clients: ["emulerr"]
   # ssl_verification: false # Optional: Defaults to true
   # request_timeout: 15 # Optional: Request timeout in seconds. Defaults to 15. Can be overridden per instance.
-  # private_tracker_handling: "obsolete_tag" # remove, skip, obsolete_tag. Optional. Default: remove
-  # public_tracker_handling: "remove"  # remove, skip, obsolete_tag. Optional. Default: remove
+  # private_tracker_handling: "obsolete_tag" # remove, remove_from_queue, skip, obsolete_tag. Optional. Default: remove
+  # public_tracker_handling: "remove"  # remove, remove_from_queue, skip, obsolete_tag. Optional. Default: remove
   # obsolete_tag: "Obsolete" # optional. Default: "Obsolete"
   # protected_tag: "Keep" # optional. Default: "Keep"
 

--- a/src/jobs/removal_handler.py
+++ b/src/jobs/removal_handler.py
@@ -21,6 +21,13 @@ class RemovalHandler:
 
             if handling_method == "remove":
                 await self._remove_download(affected_download, download_id, blocklist)
+            elif handling_method == "remove_from_queue":
+                await self._remove_download(
+                    affected_download,
+                    download_id,
+                    blocklist,
+                    remove_from_client=False,
+                )
             elif handling_method == "obsolete_tag":
                 await self._tag_as_obsolete(affected_download, download_id)
 
@@ -31,13 +38,23 @@ class RemovalHandler:
 
             self.arr.tracker.deleted.append(download_id)
 
-    async def _remove_download(self, affected_download, download_id, blocklist):
+    async def _remove_download(
+        self, affected_download, download_id, blocklist, *, remove_from_client=True
+    ):
         queue_id = affected_download["queue_ids"][0]
+        action = "removal" if remove_from_client else "queue removal (torrent kept)"
         logger.info(
-            f"Job '{self.job_name}' triggered removal: {affected_download['title']}"
+            f"Job '{self.job_name}' triggered {action}: {affected_download['title']}"
         )
-        logger.debug(f"remove_handler.py/_remove_download: download_id={download_id}")
-        await self.arr.remove_queue_item(queue_id=queue_id, blocklist=blocklist)
+        logger.debug(
+            f"remove_handler.py/_remove_download: download_id={download_id}, "
+            f"remove_from_client={remove_from_client}"
+        )
+        await self.arr.remove_queue_item(
+            queue_id=queue_id,
+            blocklist=blocklist,
+            remove_from_client=remove_from_client,
+        )
 
     async def _tag_as_obsolete(self, affected_download, download_id):
         logger.info(

--- a/src/settings/_general.py
+++ b/src/settings/_general.py
@@ -2,7 +2,7 @@ from src.settings._config_as_yaml import get_config_as_yaml
 from src.settings._validate_data_types import validate_data_types
 from src.utils.log_setup import logger
 
-VALID_TRACKER_HANDLING = {"remove", "skip", "obsolete_tag"}
+VALID_TRACKER_HANDLING = {"remove", "remove_from_queue", "skip", "obsolete_tag"}
 
 
 class General:

--- a/src/settings/_instances.py
+++ b/src/settings/_instances.py
@@ -341,7 +341,9 @@ class ArrInstance:
                     logger.info(tip)
         return
 
-    async def remove_queue_item(self, queue_id, *, blocklist=False):
+    async def remove_queue_item(
+        self, queue_id, *, blocklist=False, remove_from_client=True
+    ):
         """
         Remove a specific queue item from the queue by its queue id.
 
@@ -350,17 +352,22 @@ class ArrInstance:
         Args:
             queue_id (str): The queue ID of the queue item to be removed.
             blocklist (bool): Whether to add the item to the blocklist. Default is False.
+            remove_from_client (bool): Whether to also delete the download from the
+                download client. Default is True. Set to False to clear only the queue
+                entry and leave the torrent in place (e.g. to keep seeding a private
+                tracker torrent that still carries a hit-and-run obligation).
 
         Returns:
             bool: Returns True if the removal was successful, False otherwise.
 
         """
         logger.debug(
-            f"_instances.py/remove_queue_item: Removing queue item, blocklist: {blocklist}"
+            f"_instances.py/remove_queue_item: Removing queue item, blocklist: {blocklist}, "
+            f"remove_from_client: {remove_from_client}"
         )
         endpoint = f"{self.api_url}/queue/{queue_id}"
         headers = {"X-Api-Key": self.api_key}
-        query = {"removeFromClient": True, "blocklist": blocklist}
+        query = {"removeFromClient": remove_from_client, "blocklist": blocklist}
 
         # Send the request to remove the download from the queue
         response = await make_request(

--- a/tests/jobs/test_removal_handler.py
+++ b/tests/jobs/test_removal_handler.py
@@ -72,3 +72,67 @@ async def test_tag_as_obsolete_skips_not_ready_qbit():
 
     ready_qbit.set_tag.assert_awaited_once()
     degraded_qbit.set_tag.assert_not_awaited()
+
+
+def _handler_for(handling_method):
+    """RemovalHandler wired so every download resolves to the given handling method."""
+    arr = AsyncMock()
+    arr.tracker.deleted = []
+    arr.tracker.private = ["hash1"]
+
+    settings = MagicMock()
+    settings.download_clients.qbittorrent = [AsyncMock(ready=True)]
+    settings.download_clients.get_download_client_by_name.return_value = (
+        "qbt",
+        "qbittorrent",
+    )
+    settings.general.private_tracker_handling = handling_method
+    settings.general.public_tracker_handling = handling_method
+
+    handler = RemovalHandler(arr=arr, settings=settings, job_name="remove_stalled")
+    return handler, arr, settings
+
+
+def _affected(title="Some.Release"):
+    return {
+        "hash1": {
+            "downloadClient": "qbt",
+            "protocol": "torrent",
+            "queue_ids": [42],
+            "title": title,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_remove_from_queue_keeps_the_torrent_in_the_client():
+    """remove_from_queue clears the arr queue entry but must not delete the download."""
+    handler, arr, _ = _handler_for("remove_from_queue")
+
+    await handler.remove_downloads(_affected(), blocklist=True)
+
+    arr.remove_queue_item.assert_awaited_once_with(
+        queue_id=42, blocklist=True, remove_from_client=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_remove_from_queue_does_not_tag_the_torrent():
+    """Unlike obsolete_tag, this mode acts on the arr side only."""
+    handler, _, settings = _handler_for("remove_from_queue")
+
+    await handler.remove_downloads(_affected(), blocklist=True)
+
+    settings.download_clients.qbittorrent[0].set_tag.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_remove_still_deletes_from_the_client():
+    """The existing remove mode is unchanged."""
+    handler, arr, _ = _handler_for("remove")
+
+    await handler.remove_downloads(_affected(), blocklist=True)
+
+    assert (
+        arr.remove_queue_item.await_args.kwargs.get("remove_from_client", True) is True
+    )

--- a/tests/jobs/test_remove_metadata_missing.py
+++ b/tests/jobs/test_remove_metadata_missing.py
@@ -274,7 +274,7 @@ async def test_run_detects_metadata_stuck_item_present_only_in_full_queue():
         queue_scope="full"
     )
     removal_job.arr.remove_queue_item.assert_awaited_once_with(
-        queue_id=full_only_item["id"], blocklist=True
+        queue_id=full_only_item["id"], blocklist=True, remove_from_client=True
     )
 
 
@@ -293,7 +293,7 @@ async def test_run_still_detects_metadata_stuck_item_in_normal_queue():
 
     assert removed == 1
     removal_job.arr.remove_queue_item.assert_awaited_once_with(
-        queue_id=normal_item["id"], blocklist=True
+        queue_id=normal_item["id"], blocklist=True, remove_from_client=True
     )
 
 
@@ -348,7 +348,7 @@ async def test_run_keeps_ignored_client_and_protected_tag_downloads():
 
     assert removed == 1
     removal_job.arr.remove_queue_item.assert_awaited_once_with(
-        queue_id=removable_item["id"], blocklist=True
+        queue_id=removable_item["id"], blocklist=True, remove_from_client=True
     )
     assert removal_job.arr.tracker.deleted == [removable_item["downloadId"]]
 
@@ -380,7 +380,7 @@ async def test_run_preserves_strikes_and_blocklist_for_full_only_item():
         == 2
     )
     removal_job.arr.remove_queue_item.assert_awaited_once_with(
-        queue_id=full_only_item["id"], blocklist=True
+        queue_id=full_only_item["id"], blocklist=True, remove_from_client=True
     )
 
 
@@ -395,7 +395,7 @@ async def test_run_removes_duplicate_queue_rows_only_once():
 
     assert removed == 1
     removal_job.arr.remove_queue_item.assert_awaited_once_with(
-        queue_id=first_row["id"], blocklist=True
+        queue_id=first_row["id"], blocklist=True, remove_from_client=True
     )
     assert removal_job.arr.tracker.deleted == [first_row["downloadId"]]
 
@@ -423,6 +423,6 @@ async def test_missing_size_opt_in_remains_limited_to_normal_queue():
 
     assert removed == 1
     removal_job.arr.remove_queue_item.assert_awaited_once_with(
-        queue_id=normal_size_zero["id"], blocklist=True
+        queue_id=normal_size_zero["id"], blocklist=True, remove_from_client=True
     )
     assert removal_job.arr.tracker.deleted == [normal_size_zero["downloadId"]]

--- a/tests/settings/test_general.py
+++ b/tests/settings/test_general.py
@@ -11,3 +11,10 @@ def test_request_timeout_accepts_numeric_strings():
     general = General({"general": {"request_timeout": "42"}})
 
     assert general.request_timeout == 42.0
+
+
+def test_remove_from_queue_is_a_valid_tracker_handling_value():
+    """remove_from_queue clears the arr queue while leaving the torrent in the client."""
+    general = General({"general": {"private_tracker_handling": "remove_from_queue"}})
+
+    assert general.private_tracker_handling == "remove_from_queue"

--- a/tests/settings/test_instances.py
+++ b/tests/settings/test_instances.py
@@ -199,3 +199,43 @@ async def test_setup_wrong_arr_type_and_old_version_still_pass():
         assert await arr.setup() is True
 
     assert arr.ready is True
+
+
+def _arr_for_queue_removal():
+    arr = ArrInstance.__new__(ArrInstance)
+    arr.api_url = "http://sonarr/api/v3"
+    arr.api_key = "test_key"
+    arr.settings = MagicMock()
+    arr._timeout = 15
+    return arr
+
+
+@pytest.mark.asyncio
+async def test_remove_queue_item_deletes_from_client_by_default():
+    arr = _arr_for_queue_removal()
+
+    with patch(
+        "src.settings._instances.make_request", new=AsyncMock()
+    ) as mocked_request:
+        mocked_request.return_value = MagicMock(status_code=200)
+        await arr.remove_queue_item(queue_id=7, blocklist=True)
+
+    assert mocked_request.call_args.kwargs["params"]["removeFromClient"] is True
+
+
+@pytest.mark.asyncio
+async def test_remove_queue_item_can_leave_the_torrent_in_the_client():
+    """remove_from_client=False clears the queue entry but keeps the torrent seeding."""
+    arr = _arr_for_queue_removal()
+
+    with patch(
+        "src.settings._instances.make_request", new=AsyncMock()
+    ) as mocked_request:
+        mocked_request.return_value = MagicMock(status_code=200)
+        await arr.remove_queue_item(
+            queue_id=7, blocklist=True, remove_from_client=False
+        )
+
+    params = mocked_request.call_args.kwargs["params"]
+    assert params["removeFromClient"] is False
+    assert params["blocklist"] is True


### PR DESCRIPTION
Private-tracker torrents currently have no handling option that clears the *arr queue without also deleting the download. `remove` passes `removeFromClient=true`, which stops seeding and can trigger a hit-and-run penalty; `obsolete_tag` only tags the torrent and leaves the queue entry in place indefinitely, so the *arr keeps waiting on a download that will never import.

remove_from_queue is `remove` minus the client deletion: the queue entry is cleared and blocklisted per the job's existing blocklist policy, while the torrent stays in the client for an external tool to retire on the tracker's terms.

`remove_queue_item()` gains a `remove_from_client` keyword, defaulting to `True` so existing behavior is unchanged.

> "Isn't this what obsolete_tag already does?"

Not exactly:

| `*_tracker_handling` | *arr queue entry | torrent |
|---|---|---|
| `remove` | cleared | **deleted** |
| `obsolete_tag` | **left in place** | kept, tagged |
| `remove_from_queue` *(this PR)* | cleared | kept |