### PR TITLE
[Bug] Fix jobs configured as bare true/dict losing their built-in defaults (max_strikes, message_patterns)

### DIFF
--- a/src/settings/_jobs.py
+++ b/src/settings/_jobs.py
@@ -127,14 +127,14 @@ class Jobs:
         ):  # this triggers only when reading from yaml-file. for docker-compose, empty configs are not loaded, thus the entire job would not be parsed
             job.enabled = True
         elif isinstance(job_config, bool):
-            if job:
+            if job is not None:
                 job.enabled = job_config
             else:
                 job = JobParams(enabled=job_config)
         elif isinstance(job_config, dict):
             job_config.setdefault("enabled", True)
 
-            if job:
+            if job is not None:
                 for key, value in job_config.items():
                     setattr(job, key, value)
             else:

--- a/tests/settings/test_jobs.py
+++ b/tests/settings/test_jobs.py
@@ -8,3 +8,38 @@ def test_job_params_truthiness_is_false_by_default():
 def test_job_params_truthiness_reflects_enabled_flag():
     assert JobParams(enabled=True)
     assert not JobParams(enabled=False)
+
+
+class _FakeSettings:
+    class general:
+        obsolete_tag = "Obsolete"
+
+
+def _jobs(jobs_config):
+    from src.settings._jobs import Jobs
+
+    return Jobs({"jobs": jobs_config}, _FakeSettings())
+
+
+def test_bool_true_keeps_job_defaults():
+    # Regression: JobParams.__bool__ made the pre-built defaults object falsy
+    # (enabled=False), so `remove_failed_imports: true` was replaced by a bare
+    # JobParams(enabled=True) and lost message_patterns -> AttributeError at runtime.
+    jobs = _jobs({"remove_failed_imports": True, "remove_stalled": True})
+    assert jobs.remove_failed_imports.enabled is True
+    assert jobs.remove_failed_imports.message_patterns == ["*"]
+    assert jobs.remove_stalled.enabled is True
+    assert jobs.remove_stalled.max_strikes == 3
+
+
+def test_bool_false_keeps_job_defaults():
+    jobs = _jobs({"remove_failed_imports": False})
+    assert jobs.remove_failed_imports.enabled is False
+    assert jobs.remove_failed_imports.message_patterns == ["*"]
+
+
+def test_dict_merges_onto_job_defaults():
+    jobs = _jobs({"remove_failed_imports": {"message_patterns": ["Not an upgrade*"]}, "remove_stalled": {"max_strikes": 5}})
+    assert jobs.remove_failed_imports.enabled is True
+    assert jobs.remove_failed_imports.message_patterns == ["Not an upgrade*"]
+    assert jobs.remove_stalled.max_strikes == 5


### PR DESCRIPTION
## Summary

On `dev`, any job configured as a bare boolean (`remove_failed_imports: true`) or as a dict (`remove_slow: {min_speed: 25}`) loses the job's built-in defaults. Two visible effects:

- `remove_failed_imports: true` → `'JobParams' object has no attribute 'message_patterns'` on every cycle (caught by the #333 error boundary, so the whole removal group for that *arr is skipped).
- `remove_stalled: true`, `remove_slow: {...}`, `remove_metadata_missing: true` silently lose `max_strikes`. `RemovalJob` reads it with `getattr(self.job, "max_strikes", None)` and skips the `StrikesHandler` when it is `None`, so these jobs remove **on first sight** instead of after 3 strikes.

`:latest` (v2.1.0) is not affected.

## Cause

#333 added `JobParams.__bool__` (truthiness = `enabled`). `Jobs._set_job_settings` uses `if job:` to decide whether to reuse the pre-built defaults object from `_set_job_defaults()`, and those objects start with `enabled=False` — so the check is now always false and the job is rebuilt as `JobParams(**user_keys)` with nothing else.

## Fix

`if job:` → `if job is not None:` in both the bool and dict branches, which is what the code meant before `__bool__` existed.

Reproduced on the current `:dev` image (2026-07-21):

```
# before                                     # after
remove_failed_imports  {}                    {'message_patterns': ['*']}
remove_stalled         {}                    {'max_strikes': 3}
remove_metadata_missing{}                    {'max_strikes': 3, 'detect_via_missing_size': False}
remove_slow (dict)     {'min_speed': 25}     {'max_strikes': 3, 'min_speed': 25}
```

## Validation

- Added `test_bool_true_keeps_job_defaults`, `test_bool_false_keeps_job_defaults`, `test_dict_merges_onto_job_defaults` in `tests/settings/test_jobs.py` — they fail on `dev` and pass with the fix.
- Full suite: 295 passed (run inside the `:dev` image).
- Running on my own instance since the fix via a config-side workaround (defaults spelled out explicitly); `remove_failed_imports` tags items again and the strikes debounce is back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
