### PR TITLE
Re-arm removals for downloads that never left the queue

### DIFF
--- a/src/job_manager.py
+++ b/src/job_manager.py
@@ -136,11 +136,47 @@ class JobManager:
                 "job_runner/full_queue at start: %s",
                 queue_manager.format_queue(full_queue),
             )
+            self._forget_deleted_downloads_still_in_queue(full_queue)
             return True
 
         self.arr.tracker.reset()
         logger.verbose("Removal Jobs: None triggered (Queue is empty)")
         return False
+
+    def _forget_deleted_downloads_still_in_queue(self, full_queue):
+        """
+        Drop downloads from the deleted tracker that are still in the queue.
+
+        The deleted tracker stops the same download from being removed twice
+        within one run, but is otherwise only cleared once the queue is empty.
+        A download that is still in the queue was evidently not removed, so
+        keeping it in the tracker would silently suppress every future removal
+        attempt for as long as decluttarr runs.
+
+        Downloads handled via obsolete_tag are exempt: they are meant to stay in
+        the queue, so their presence is not evidence of a failed removal.
+        """
+        queue_download_ids = {item.get("downloadId") for item in full_queue} - {None}
+        still_in_queue = {
+            download_id
+            for download_id in self.arr.tracker.deleted
+            if download_id in queue_download_ids
+            and download_id not in self.arr.tracker.obsolete_tagged
+        }
+        if not still_in_queue:
+            return
+
+        logger.debug(
+            "job_manager.py/_forget_deleted_downloads_still_in_queue: "
+            "Marked as deleted but still in queue (removal did not take effect), "
+            "thus eligible for removal again: %s",
+            ", ".join(sorted(still_in_queue)),
+        )
+        self.arr.tracker.deleted = [
+            download_id
+            for download_id in self.arr.tracker.deleted
+            if download_id not in still_in_queue
+        ]
 
     async def _download_clients_connected(self):
         for clients in [

--- a/src/jobs/removal_handler.py
+++ b/src/jobs/removal_handler.py
@@ -23,6 +23,7 @@ class RemovalHandler:
                 await self._remove_download(affected_download, download_id, blocklist)
             elif handling_method == "obsolete_tag":
                 await self._tag_as_obsolete(affected_download, download_id)
+                self.arr.tracker.obsolete_tagged.append(download_id)
 
             # Print out detailed removal messages (if any)
             if "removal_messages" in affected_download:

--- a/src/settings/_instances.py
+++ b/src/settings/_instances.py
@@ -29,6 +29,7 @@ class Tracker:
         self.defective = {}
         self.download_progress = {}
         self.deleted = []
+        self.obsolete_tagged = []
         self.extension_checked = []
 
     def reset(self) -> None:
@@ -38,6 +39,7 @@ class Tracker:
             self.defective,
             self.download_progress,
             self.deleted,
+            self.obsolete_tagged,
             self.extension_checked,
         ):
             attr.clear()

--- a/tests/jobs/test_job_manager.py
+++ b/tests/jobs/test_job_manager.py
@@ -4,6 +4,9 @@ import pytest
 import requests
 
 from src.job_manager import JobManager
+from src.jobs.removal_handler import RemovalHandler
+from src.settings._instances import Tracker
+from src.utils.queue_manager import QueueManager
 
 
 @pytest.mark.asyncio
@@ -75,3 +78,136 @@ async def test_run_download_client_jobs_handles_connection_check_request_errors(
         result = await manager.run_download_client_jobs()
 
     assert result is None
+
+
+def _job_manager_with_deleted(deleted):
+    manager = JobManager(MagicMock())
+    manager.arr = MagicMock()
+    manager.arr.tracker = Tracker()
+    manager.arr.tracker.deleted.extend(deleted)
+    return manager
+
+
+def _queue_item(download_id, queue_id=1):
+    return {
+        "id": queue_id,
+        "downloadId": download_id,
+        "title": "Some.Release",
+        "protocol": "torrent",
+        "downloadClient": "qBittorrent",
+    }
+
+
+@pytest.mark.asyncio
+async def test_queue_has_items_forgets_deleted_downloads_that_are_back_in_queue():
+    """A removal that did not stick must not block all future removals.
+
+    The deleted tracker is otherwise only cleared once the queue is empty, so a
+    download that keeps coming back would be silently skipped by RemovalHandler
+    forever (strikes keep counting up, but no removal is ever triggered).
+    """
+    # Arrange
+    manager = _job_manager_with_deleted(["still-in-queue", "actually-removed"])
+
+    get_queue_items = AsyncMock(return_value=[_queue_item("still-in-queue")])
+
+    # Act
+    with patch.object(QueueManager, "get_queue_items", get_queue_items):
+        has_items = await manager._queue_has_items()  # pylint: disable=W0212
+
+    # Assert
+    assert has_items is True
+    assert manager.arr.tracker.deleted == ["actually-removed"]
+    # The orphans job that triggered this bug only shows up in the full queue
+    get_queue_items.assert_awaited_once_with("full")
+
+
+@pytest.mark.asyncio
+async def test_forgotten_download_is_removed_again_on_the_next_run():
+    """After being forgotten, the download is removed instead of silently skipped."""
+    # Arrange
+    manager = _job_manager_with_deleted(["comes-back"])
+    manager.settings.general.public_tracker_handling = "remove"
+    manager.settings.download_clients.qbittorrent = []
+    manager.settings.download_clients.get_download_client_by_name.return_value = (
+        None,
+        None,
+    )
+    manager.arr.remove_queue_item = AsyncMock()
+    queue_item = _queue_item("comes-back", queue_id=42)
+
+    # Act
+    with patch.object(
+        QueueManager, "get_queue_items", AsyncMock(return_value=[queue_item])
+    ):
+        await manager._queue_has_items()  # pylint: disable=W0212
+    await RemovalHandler(
+        arr=manager.arr,
+        settings=manager.settings,
+        job_name="remove_metadata_missing",
+    ).remove_downloads(
+        {"comes-back": {**queue_item, "queue_ids": [queue_item["id"]]}},
+        blocklist=True,
+    )
+
+    # Assert
+    manager.arr.remove_queue_item.assert_awaited_once_with(queue_id=42, blocklist=True)
+
+
+@pytest.mark.asyncio
+async def test_queue_has_items_keeps_deleted_downloads_that_are_gone():
+    """Downloads that really were removed stay in the tracker (no double removal)."""
+    # Arrange
+    manager = _job_manager_with_deleted(["actually-removed"])
+
+    # Act
+    with patch.object(
+        QueueManager,
+        "get_queue_items",
+        AsyncMock(return_value=[_queue_item("something-else")]),
+    ):
+        has_items = await manager._queue_has_items()  # pylint: disable=W0212
+
+    # Assert
+    assert has_items is True
+    assert manager.arr.tracker.deleted == ["actually-removed"]
+
+
+@pytest.mark.asyncio
+async def test_obsolete_tagged_download_is_not_tagged_again_on_the_next_run():
+    """Obsolete-tagged downloads stay in the queue by design and must not be re-tagged.
+
+    With private_tracker_handling/public_tracker_handling set to "obsolete_tag",
+    the download is tagged instead of removed and deliberately remains in the
+    queue, so its presence is not evidence of a failed removal.
+    """
+    # Arrange
+    manager = _job_manager_with_deleted([])
+    manager.settings.general.public_tracker_handling = "obsolete_tag"
+    manager.settings.general.obsolete_tag = "Obsolete"
+    qbit = MagicMock(ready=True, set_tag=AsyncMock())
+    manager.settings.download_clients.qbittorrent = [qbit]
+    manager.settings.download_clients.get_download_client_by_name.return_value = (
+        qbit,
+        "qbittorrent",
+    )
+    queue_item = _queue_item("tagged", queue_id=7)
+
+    # Act
+    for _ in range(2):
+        with patch.object(
+            QueueManager, "get_queue_items", AsyncMock(return_value=[queue_item])
+        ):
+            await manager._queue_has_items()  # pylint: disable=W0212
+        await RemovalHandler(
+            arr=manager.arr,
+            settings=manager.settings,
+            job_name="remove_stalled",
+        ).remove_downloads(
+            {"tagged": {**queue_item, "queue_ids": [queue_item["id"]]}},
+            blocklist=False,
+        )
+
+    # Assert
+    qbit.set_tag.assert_awaited_once_with(tags=["Obsolete"], hashes=["tagged"])
+    manager.arr.remove_queue_item.assert_not_called()


### PR DESCRIPTION
## Problem

A removal that does not actually take effect permanently disables every future removal of that download.

Observed on v2.1.0: one `remove_orphans` removal recorded a hash as deleted, but the torrent was never removed from qBittorrent. `remove_metadata_missing` then flagged the same download for ~19 hours, climbing to 74 strikes against `max_strikes: 5`, with zero removals and zero blocklist entries. Nothing in the log said the removal was being skipped.

## Root cause

`arr.tracker.deleted` is process-lifetime state that gates every removal:

- `src/jobs/removal_handler.py:18` silently drops any download whose id is already in that list.
- `src/jobs/removal_handler.py:32` appends to it unconditionally, after the removal attempt, without checking whether the removal worked (`remove_queue_item`'s return value is discarded at line 40).
- The list is only ever cleared by `Tracker.reset()`, whose sole call site is `src/job_manager.py:141` — the branch taken only when the *arr queue is completely empty.

So a download that cannot be removed keeps the queue non-empty, which keeps the list from ever being cleared, which keeps that download suppressed for the life of the process. Strikes keep counting up; nothing else happens. Same code on v2.1.0 and current dev.

## Fix

Prune the tracker at the start of each run, inside `_queue_has_items()`, using the full queue it already fetched (no extra API call). If a download recorded as deleted is still in the queue, the removal did not take effect, so it becomes eligible again.

`_queue_has_items()` is already the tracker-lifecycle method — it holds the only `Tracker.reset()` call — so both branches of that one predicate now manage the list: queue empty resets everything, queue non-empty drops the entries the queue itself disproves.

### obsolete_tag is exempt

`obsolete_tag` handling deliberately leaves the download in the *arr queue so qbit_manage can reap it later (README.md:441), and `removal_handler.py:32` appends to `tracker.deleted` after that branch too. One list was carrying two different meanings: "we removed this" and "we already tagged this, leave it alone". Queue presence only disproves the first.

Tagged ids are therefore recorded in a separate `Tracker.obsolete_tagged` list (cleared by the same `reset()`) that the prune skips. Without this, an obsolete-tagged torrent is re-tagged and re-logged on every cycle for as long as it lingers — measured below.

## Behaviour changes worth knowing

- For the six jobs without `max_strikes` (`remove_orphans`, `remove_unmonitored`, `remove_missing_files`, `remove_failed_downloads`, `remove_failed_imports`, `remove_bad_files`), a download that genuinely cannot be removed is now retried once per cycle instead of once per process. That is the intended consequence of no longer suppressing failed removals, and matches what the strike-based jobs already do — see the existing tip at `strikes_handler.py:199`.
- In `test_run` mode the DELETE is simulated, so the download stays in the queue and each candidate is now reported every cycle rather than once per process. This matches `download_client_removal_job.py:99-104`, which already logs "Would have removed" on every cycle.
- The cross-cycle reader at `strikes_handler.py:143-154` is unaffected: entries for downloads that really are gone are still kept, so "deleted in previous round" keeps classifying correctly.

## Alternatives considered

Clearing `tracker.deleted` unconditionally each cycle is a one-liner and also fixes the bug, but it is strictly less precise and destroys the only cross-cycle consumer of the list: `strikes_handler.py:143-154` distinguishes "deleted in previous round" (debug) from "no longer in queue" (verbose), and blind clearing reclassifies every successful removal into the wrong branch on the following cycle. VERBOSE is a documented level (README.md:389-392). The prune keeps that intact because it only forgets ids the queue proves are still present.

Gating the append on `remove_queue_item`'s boolean is worth doing but is a different bug: in this incident the *arr returned 200 and accepted the DELETE — the removal just did not stick — so that change would not have helped here. It also has no defined meaning for the `obsolete_tag` branch, which produces no such boolean.

## Testing

Locally on dev, Python 3.14, project venv.

- Full suite: `python -m pytest -o log_cli=false` — 296 passed.
- `ruff format --check` on both edited-heavily files: already formatted. (`removal_handler.py` and `_instances.py` report reformat suggestions, but those are pre-existing at HEAD and not on the changed lines — verified by stashing.)

Reproduction of the `obsolete_tag` case, driving `JobManager._queue_has_items` -> `RemovalHandler.remove_downloads` over three cycles with a real `Tracker`, one private stalled torrent held in the queue, `private_tracker_handling: obsolete_tag`, only the HTTP boundary mocked. Cumulative `qbit.set_tag` awaits per cycle:

```
prune without the exemption   [1, 2, 3]   re-tagged every cycle
prune with the exemption      [1, 1, 1]   tagged once, as before
```

`remove_queue_item` stayed at 0 in both runs.

Mutation checks — each of these was applied to the tree with the tests left in place, and each is caught:

| Mutation | Result |
| --- | --- |
| Revert `src/job_manager.py` to dev, keep the tests | 2 failed |
| Drop the `obsolete_tag` exemption from the prune | 1 failed |
| Drop the `obsolete_tagged` bookkeeping in `removal_handler` | 1 failed |
| Invert the prune predicate (forget the ids that are gone) | 3 failed |
| Query the `normal` queue instead of `full` | 1 failed |

The last one matters because `remove_orphans` — the job that poisoned the tracker in the original incident — only appears in the full queue, so the test now pins that scope explicitly.

## Changes

- `src/job_manager.py` — `_forget_deleted_downloads_still_in_queue()`, called from the non-empty branch of `_queue_has_items()`.
- `src/settings/_instances.py` — `Tracker.obsolete_tagged`, cleared alongside the rest in `reset()`.
- `src/jobs/removal_handler.py` — record tag-only ids in that list.
- `tests/jobs/test_job_manager.py` — four tests: prune forgets a download still in the queue, that download is then removed on the next run, a genuinely removed download stays suppressed, and an obsolete-tagged download is tagged exactly once across two cycles.

No config, README, or behaviour-flag changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)